### PR TITLE
APIKEY as env variable

### DIFF
--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -305,7 +305,7 @@ override configuration file options:
 .Bl -offset indent
 .It
 .Ic DNSDB_API_KEY :
-contains the user's apikey
+contains the user's apikey. If not present, then APIKEY, if set, will be used.
 .It
 .Ic DNSDB_SERVER :
 contains the URL of the DNSDB API server


### PR DESCRIPTION
Documented that APIKEY can also be used as an environment variable, but as secondary to DNSDB_API_KEY