### PR TITLE
Switch from mktime to timegm and remove buggy UTC offset conversion; …

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -228,7 +228,6 @@ static present_t pres = present_text;
 static int limit = 0;
 static CURLM *multi = NULL;
 static struct timeval now;
-static struct timezone here;
 static int nkeys, keys[MAX_KEYS];
 static writer_t writers = NULL;
 
@@ -244,7 +243,7 @@ main(int argc, char *argv[]) {
 	int ch;
 
 	/* global dynamic initialization. */
-	gettimeofday(&now, &here);
+	gettimeofday(&now, NULL);
 	program_name = strrchr(argv[0], '/');
 	if (program_name != NULL)
 		program_name++;
@@ -2104,7 +2103,7 @@ time_get(const char *src, u_long *dst) {
 	if (((ep = strptime(src, "%F %T", &tt)) != NULL && *ep == '\0') ||
 	    ((ep = strptime(src, "%F", &tt)) != NULL && *ep == '\0'))
 	{
-		*dst = (u_long)(mktime(&tt) - here.tz_minuteswest);
+		*dst = (u_long)(timegm(&tt));
 		return (1);
 	}
 	ll = strtoll(src, &ep, 10);

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -198,9 +198,9 @@ positive unsigned integer : in Unix epoch format.
 .It
 negative unsigned integer : negative offset in seconds from now.
 .It
-YYYY-MM-DD [HH:MM:SS] : in absolute form, in the local time (zone), but DNSDB does its fencing using UTC time.  You should adjust your timestamps appropriately.
+YYYY-MM-DD [HH:MM:SS] : in absolute form, in UTC time, as DNSDB does its fencing using UTC time.
 .It
-%dw%dd%dh%dm%ds : the relative form with explicit labels.  Calculates offsite from the local time, but DNSDB does its fencing using UTC time.  You should adjust your timestamps appropriately.
+%dw%dd%dh%dm%ds : the relative form with explicit labels.  Calculates offsite from UTC time, as DNSDB does its fencing using UTC time.
 .Pp
 .El
 A few examples of how to use timefencing options.


### PR DESCRIPTION
…document that timestamps passed to dnsdbq will be interpreted in UTC