### PR TITLE
Fix output limit when sorting the output

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -1471,7 +1471,8 @@ writer_func(char *ptr, size_t size, size_t nmemb, void *blob) {
 			return (bytes);
 		}
 
-		if (output_limit != 0 &&
+		if (sorted == no_sort &&
+		    output_limit != 0 &&
 		    reader->writer->count >= output_limit)
 		{
 			if (debuglev > 2)


### PR DESCRIPTION
The following now give identical output, as desired:

```
$ dnsdbq -s -k count -r bbn.com -j -l 100 | head -2
$ dnsdbq -s -k count -r bbn.com -j -l 100 -L 2
```