### PR TITLE
Apply bailiwick filter when rrtype is not specified.

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -947,6 +947,9 @@ makepath(mode_e mode, const char *name, const char *rrtype,
 		else if (rrtype != NULL)
 			x = asprintf(&command, "rrset/name/%s/%s",
 				     name, rrtype);
+		else if (bailiwick != NULL)
+			x = asprintf(&command, "rrset/name/%s/ANY/%s",
+				     name, bailiwick);
 		else
 			x = asprintf(&command, "rrset/name/%s",
 				     name);


### PR DESCRIPTION
Handles case where only a bailiwick filter is given for an rrset query by using rrtype ANY.

dnsdbq previously ignored the bailiwick filter if no rrtype was given.