### PR TITLE
make -s/-S work even if -k is not specified

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -755,8 +755,6 @@ add_sort_key(const char *tok) {
 	if (key == NULL)
 		return ("key must be one of first, "
 		      "last, count, name, or data");
-	if (nkeys == MAX_KEYS)
-		return ("too many -k options");
 	keys[nkeys++] = key;
 	return (NULL);
 }

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -145,6 +145,8 @@ specify newline delimited json output mode.
 .It Fl k Ar sort_keys
 when sorting with -s or -S, selects one or more comma separated sort keys,
 among "first", "last", "count", "name", and/or "data".
+If sorting was specified, but this -k option is not specified, then will default
+to sorting by first, last, count.
 .It Fl l Ar limit
 query for that limit's number of responses. If specified as 0 then the DNSDB
 API server will return the maximum limit of results allowed.  If

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -19,6 +19,7 @@
 .Nm dnsdbq
 .Nd DNSDB query tool
 .Sh SYNOPSIS
+.Nm dnsdbq
 .Op Fl dfmhjsShcI
 .Op Fl A Ar timestamp
 .Op Fl B Ar timestamp


### PR DESCRIPTION
when we changed the logic to not use -r on POSIX sort, but to instead add the "r" qualifier to all keys, we forgot to ensure that there would be at least one key. so, the default for -k is now first,last,count, if -s or -S is given. also one small man page change.