### PR TITLE
use -u on sort to prevent duplicate answers when making multiple upst…

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -440,7 +440,7 @@ main(int argc, char *argv[]) {
 			const char *tok;
 			if (nkeys > 0)
 				usage("Can only specify -k once; use commas "
-				      "to seperate multiple sort fields");
+				      "to separate multiple sort fields");
 
 			nkeys = 0;
 			for (tok = strtok(optarg, ",");
@@ -448,6 +448,9 @@ main(int argc, char *argv[]) {
 			     tok = strtok(NULL, ","))
 			{
 				const char *msg;
+
+				if (find_sort_key(tok) != NULL)
+					usage("Each sort key may only be specified once");
 
 				if ((msg = add_sort_key(tok)) != NULL)
 					usage(msg);

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -149,6 +149,7 @@ when sorting with -s or -S, selects one or more comma separated sort keys,
 among "first", "last", "count", "name", and/or "data".
 If sorting was specified, but this -k option is not specified, then will default
 to sorting by first, last, count.
+Each sort key may only be specified once.
 .It Fl l Ar limit
 query for that limit's number of responses. If specified as 0 then the DNSDB
 API server will return the maximum limit of results allowed.  If


### PR DESCRIPTION
"Is it possible that two queries were run (one for the -A and one for the -B), but the results were never deduplicated?"

in "/usr/bin/sort" args: [sort] [-k3nr]", -u is missing. i must have broken this when i fixed the other recent sort-related problem. sadly, this means all keys must be specified to sort, even if the -k arguments were incomplete.

closed sort_stdin, wrote 288 objs
closed sort_stdout, read 288 objs (lim 1000000)

this is with the version you're running. it wrote 288 and read all of them.

closed sort_stdin, wrote 288 objs
closed sort_stdout, read 144 objs (lim 1000000)

this is the version patched by this PR. it wrote 288 and read half.

"/usr/bin/sort" args: [sort] [-u] [-k3nr] [-k1nr] [-k2nr] [-k4r] [-k5r]
