### PR TITLE
dnsdbq july2019 updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2018 by Farsight Security, Inc.
+Copyright (c) 2014-2019 by Farsight Security, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -2706,7 +2706,7 @@ dnsdb_url(const char *path, char *sep) {
 	 */
 	if (page > 0) {
 		x = snprintf(skip_if_needed, sizeof(skip_if_needed),
-			     "&skip=%d", page * query_limit);
+			     "&skip=%lu", (u_long)(page * query_limit));
 		if (x < 0) {
 			perror("snprintf");
 			ret = NULL;

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -286,7 +286,7 @@ static const struct verb verbs[] = {
 
 static const char *program_name = NULL;
 static char *api_key = NULL;
-static verb_t choosen_verb = &verbs[0];
+static verb_t chosen_verb = &verbs[0];
 static char *dnsdb_base_url = NULL;
 #if WANT_PDNS_CIRCL
 static char *circl_base_url = NULL;
@@ -368,9 +368,9 @@ main(int argc, char *argv[]) {
 
 			p = strchr(optarg, '/');
 			if (p != NULL) {
-                                if (rrtype != NULL || bailiwick != NULL)
-                                        usage("if -b or -t are specified then "
-                                              "-r cannot contain a slash");
+				if (rrtype != NULL || bailiwick != NULL)
+					usage("if -b or -t are specified then "
+					      "-r cannot contain a slash");
 
 				const char *q;
 
@@ -440,8 +440,8 @@ main(int argc, char *argv[]) {
 			break;
 		    }
 		case 'V': {
-			choosen_verb = find_verb(optarg);
-			if (choosen_verb == NULL)
+			chosen_verb = find_verb(optarg);
+			if (chosen_verb == NULL)
 				usage("Unsupported verb for -V argument");
 			break;
 		    }
@@ -642,11 +642,11 @@ main(int argc, char *argv[]) {
 			(void) add_sort_key("data");
 	}
 
-	assert(choosen_verb != NULL);
-	if (choosen_verb->validate_cmd_opts != NULL)
-		(*choosen_verb->validate_cmd_opts)();
+	assert(chosen_verb != NULL);
+	if (chosen_verb->validate_cmd_opts != NULL)
+		(*chosen_verb->validate_cmd_opts)();
 	if (sys->validate_verb != NULL)
-		if (sys->validate_verb(choosen_verb->cmd_opt_val) == false)
+		if (sys->validate_verb(chosen_verb->cmd_opt_val) == false)
 			usage("That verb is not supported by that system");
 
 	/* get some input from somewhere, and use it to drive our output. */
@@ -733,7 +733,7 @@ help(void) {
 	verb_t v;
 
 	fprintf(stderr,
-"usage: %s [-djsShcIg] [-p dns|json|csv] [-k (first|last|count|name|data)[,...]]\n"
+"usage: %s [-djsShcIgv] [-p dns|json|csv] [-k (first|last|count|name|data)[,...]]\n"
 "\t[-l QUERY-LIMIT] [-L OUTPUT-LIMIT] [-A after] [-B before] [-u system] [-O offset] [-V verb] [-M max_count]{\n"
 "\t\t-f |\n"
 "\t\t-J inputfile |\n"
@@ -874,7 +874,7 @@ static void
 validate_cmd_opts_summarize(void)
 {
 	if (pres != present_json)
-		usage("Only json output mode is supposed with a summarize verb");
+		usage("Only json output mode is supported with a summarize verb");
 	if (sorted != no_sort)
 		usage("Sorting with a summarize verb makes no sense");
 	/*TODO add more validations? */
@@ -2723,11 +2723,11 @@ dnsdb_url(const char *path, char *sep) {
 	for (p = dnsdb_base_url; *p != '\0'; p++)
 		x += (*p == '/');
 	if (x < 3)
-		if (choosen_verb != NULL && choosen_verb->url_fragment != NULL)
-			verb_path = choosen_verb->url_fragment;
+		if (chosen_verb != NULL && chosen_verb->url_fragment != NULL)
+			verb_path = chosen_verb->url_fragment;
 		else
 			verb_path = "/lookup";
-	else if (choosen_verb != &verbs[0])
+	else if (chosen_verb != &verbs[0])
 		usage("Cannot specify a verb other than 'lookup' "
 		      "if the server contains a path");
 	else

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -150,13 +150,15 @@ typedef const struct sortkey *sortkey_ct;
 struct dnsdb_rate_json {
 	json_t	*main,
 		*reset, *expires, *limit, *remaining,
-		*burst_size, *burst_window, *results_max;
+		*burst_size, *burst_window, *results_max,
+		*offset_max;
 };
 
 struct dnsdb_rate_tuple {
 	struct dnsdb_rate_json	obj;
 	struct rateval	reset, expires, limit, remaining,
-			burst_size, burst_window, results_max;
+			burst_size, burst_window, results_max,
+			offset_max;
 };
 typedef struct dnsdb_rate_tuple *dnsdb_rate_tuple_t;
 
@@ -1574,6 +1576,7 @@ dnsdb_write_info(reader_t reader) {
 			print_rateval(stdout, "limit", &tup.limit);
 			print_rateval(stdout, "remaining", &tup.remaining);
 			print_rateval(stdout, "results_max", &tup.results_max);
+			print_rateval(stdout, "offset_max", &tup.offset_max);
 			print_burstrate(stdout, "burst rate",
 					&tup.burst_size, &tup.burst_window);
 		}
@@ -2406,6 +2409,10 @@ dnsdb_rate_tuple_make(dnsdb_rate_tuple_t tup, const char *buf, size_t len) {
 		goto ouch;
 
 	msg = rateval_make(&tup->results_max, rate, "results_max");
+	if (msg != NULL)
+		goto ouch;
+
+	msg = rateval_make(&tup->offset_max, rate, "offset_max");
 	if (msg != NULL)
 		goto ouch;
 

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -368,9 +368,9 @@ main(int argc, char *argv[]) {
 
 			p = strchr(optarg, '/');
 			if (p != NULL) {
-			    if (rrtype != NULL || bailiwick != NULL)
-				usage("if -b or -t are specified then -r "
-				      "cannot contain a slash");
+                                if (rrtype != NULL || bailiwick != NULL)
+                                        usage("if -b or -t are specified then "
+                                              "-r cannot contain a slash");
 
 				const char *q;
 

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -2674,8 +2674,8 @@ sortable_dnsname(sortbuf_t buf, const char *name) {
 static char *
 dnsdb_url(const char *path, char *sep) {
 	const char *verb_path, *p, *scheme_if_needed, *aggr_if_needed;
-	char skip_if_needed[sizeof("&skip=##################")] = "";
-        char max_count_if_needed[sizeof("&skip=##################")] = "";
+	char offset_if_needed[sizeof("&offset=##################")] = "";
+        char max_count_if_needed[sizeof("&max_count=##################")] = "";
 	char *ret;
 	int x;
 
@@ -2714,11 +2714,11 @@ dnsdb_url(const char *path, char *sep) {
 		aggr_if_needed = "&aggr=f";
 
 	/* if page > 0, we already ensured the query_limit > 0,
-	 * so skip that many rows of results.
+	 * so offset (e.g. skip) that many rows of results.
 	 */
 	if (page > 0) {
-		x = snprintf(skip_if_needed, sizeof(skip_if_needed),
-			     "&skip=%lu", (u_long)(page * query_limit));
+		x = snprintf(offset_if_needed, sizeof(offset_if_needed),
+			     "&offset=%lu", (u_long)(page * query_limit));
 		if (x < 0) {
 			perror("snprintf");
 			ret = NULL;
@@ -2742,7 +2742,7 @@ dnsdb_url(const char *path, char *sep) {
 	 */
 	x = asprintf(&ret, "%s%s%s/%s?swclient=%s&version=%s%s%s%s",
 		     scheme_if_needed, dnsdb_base_url, verb_path, path,
-		     id_swclient, id_version, aggr_if_needed, skip_if_needed, max_count_if_needed);
+		     id_swclient, id_version, aggr_if_needed, offset_if_needed, max_count_if_needed);
 	if (x < 0) {
 		perror("asprintf");
 		ret = NULL;

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -726,7 +726,7 @@ help(void) {
 	verb_t v;
 
 	fprintf(stderr,
-"usage: %s [-djsShcIg] [-p dns|json|csv] [-k (first|last|count)[,...]]\n"
+"usage: %s [-djsShcIg] [-p dns|json|csv] [-k (first|last|count|name|data)[,...]]\n"
 "\t[-l QUERY-LIMIT] [-L OUTPUT-LIMIT] [-A after] [-B before] [-u system] [-P page_number] [-V verb] {\n"
 "\t\t-f |\n"
 "\t\t-J inputfile |\n"
@@ -736,33 +736,34 @@ help(void) {
 "\t\t\t-i IP[/PFXLEN]\n"
 "\t\t\t-R RAW-DATA[/TYPE] |\n"
 "\t\t}\n"
-"\t}\n"
-"for -f, stdin must contain lines of the following forms:\n"
-"\trrset/name/NAME[/TYPE[/BAILIWICK]]\n"
-"\trdata/name/NAME[/TYPE]\n"
-"\trdata/ip/ADDR[/PFXLEN]\n"
-"for -f, output format will be determined by -p, using --\\n framing\n"
-"for -J, input format is newline-separated JSON, as for -j output\n"
-"for -A and -B, use abs. YYYY-MM-DD[ HH:MM:SS] "
-		"or rel. %%dw%%dd%%dh%%dm%%ds format\n"
-"use -j as a synonym for -p json.\n"
-"use -s to sort in ascending order, or -S for descending order.\n"
-"use -h to reliably display this helpful text.\n"
-"use -c to get complete (vs. partial) time matching for -A and -B\n"
-"use -d one or more times to ramp up the diagnostic output\n"
-"use -I to see a system-specific account or key summary in JSON format\n"
-"use -g to get graveled results\n"
-"use -P # to query that page # of results.\n",
+"\t}\n",
 		program_name);
-	fprintf(stderr, "\nsystem must be one of:\n");
+        fprintf(stderr,
+"for -A and -B, use abs. YYYY-MM-DD[ HH:MM:SS] "
+		"or rel. %%dw%%dd%%dh%%dm%%ds format.\n"
+"use -c to get complete (vs. partial) time matching for -A and -B.\n"
+"use -d one or more times to ramp up the diagnostic output.\n"
+"for -f, stdin must contain lines of the following forms:\n"
+"\t  rrset/name/NAME[/TYPE[/BAILIWICK]]\n"
+"\t  rdata/name/NAME[/TYPE]\n"
+"\t  rdata/ip/ADDR[/PFXLEN]\n"
+"\t output format will be determined by -p, using --\\n framing.\n"
+"use -g to get graveled results.\n"
+"use -h to reliably display this helpful text.\n"
+"use -I to see a system-specific account or key summary in JSON format.\n"
+"for -J, input format is newline-separated JSON, as from -j output.\n"
+"use -j as a synonym for -p json.\n"
+"use -P # to query that page # of results.\n"
+"use -s to sort in ascending order, or -S for descending order.\n");
+	fprintf(stderr, "for -u, system must be one of:\n");
 	for (t = pdns_systems; t->name != NULL; t++)
-		fprintf(stderr, " %s\n", t->name);
-	fprintf(stderr, "\nverb must be one of:\n");
+		fprintf(stderr, "\t%s\n", t->name);
+	fprintf(stderr, "for -V, verb must be one of:\n");
 	for (v = verbs; v->cmd_opt_val != NULL; v++)
-		fprintf(stderr, " %s\n", v->cmd_opt_val);
-	fprintf(stderr, "\n\nGetting Started: \nAdd the API key to ~/.dnsdb-query.conf in the below given format,\n"
-		"\nAPIKEY=\"YOURAPIKEYHERE\"");
-	fprintf(stderr, "\n\ntry   man %s   for a longer description\n",
+		fprintf(stderr, "\t%s\n", v->cmd_opt_val);
+	fprintf(stderr, "\nGetting Started: \n\tAdd your API key to ~/.dnsdb-query.conf in the below given format:\n"
+		"\tAPIKEY=\"YOURAPIKEYHERE\"");
+	fprintf(stderr, "\n\nTry   man %s   for full documentation.\n",
 		program_name);
 }
 

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -848,9 +848,9 @@ static bool parse_long(const char *in, long *out)
 	char *ep;
 	long result = strtol(in, &ep, 10);
 
-	if ((errno == ERANGE && (result == LONG_MAX || result == LONG_MIN))
-	    || (errno != 0 && result == 0)
-	    || (ep == in))
+	if ((errno == ERANGE && (result == LONG_MAX || result == LONG_MIN)) ||
+	    (errno != 0 && result == 0) ||
+	    (ep == in))
 		return false;
 	*out = result;
 	return true;

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -745,7 +745,7 @@ help(void) {
 "\t\t}\n"
 "\t}\n",
 		program_name);
-        fprintf(stderr,
+	fprintf(stderr,
 "for -A and -B, use abs. YYYY-MM-DD[ HH:MM:SS] "
 		"or rel. %%dw%%dd%%dh%%dm%%ds format.\n"
 "use -c to get complete (vs. partial) time matching for -A and -B.\n"
@@ -844,7 +844,7 @@ void validate_cmd_opts_lookup(void)
 {
 	/* $$$ too many local variables would need to be global to check more here */
 
-        if (max_count > 0)
+	if (max_count > 0)
 		usage("max_count only allowed for a summarize verb");
 }
 
@@ -2675,7 +2675,7 @@ static char *
 dnsdb_url(const char *path, char *sep) {
 	const char *verb_path, *p, *scheme_if_needed, *aggr_if_needed;
 	char offset_if_needed[sizeof("&offset=##################")] = "";
-        char max_count_if_needed[sizeof("&max_count=##################")] = "";
+	char max_count_if_needed[sizeof("&max_count=##################")] = "";
 	char *ret;
 	int x;
 
@@ -2725,7 +2725,7 @@ dnsdb_url(const char *path, char *sep) {
 		}
 	}
 
-        if (max_count > 0) {
+	if (max_count > 0) {
 		x = snprintf(max_count_if_needed, sizeof(max_count_if_needed),
 			     "&max_count=%lu", (u_long)(max_count));
 		if (x < 0) {

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -487,6 +487,8 @@ main(int argc, char *argv[]) {
 		case 't':
 			if (rrtype != NULL)
 				usage("can only specify rrtype one way");
+			if (mode != no_mode && mode != ip_mode)
+				fprintf(stderr, "Warning: -t option should be before the -R, -r, or -n options\n");
 			rrtype = strdup(optarg);
 			break;
 		case 'b':

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -366,19 +366,16 @@ main(int argc, char *argv[]) {
 			assert(name == NULL);
 			mode = rdata_mode;
 
-			if (rrtype == NULL)
-				p = strchr(optarg, '/');
-			else
-				p = NULL;
-
+			p = strchr(optarg, '/');
 			if (p != NULL) {
+			    if (rrtype != NULL || bailiwick != NULL)
+				usage("if -b or -t are specified then -r "
+				      "cannot contain a slash");
+
 				const char *q;
 
 				q = strchr(p + 1, '/');
 				if (q != NULL) {
-					if (bailiwick != NULL)
-						usage("can only specify "
-						      "one bailiwick");
 					bailiwick = strdup(q + 1);
 					rrtype = strndup(p + 1,
 						       (size_t)(q - p - 1));

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -35,12 +35,14 @@
 .Op Fl R Ar raw_rdata
 .Op Fl r Ar rdata
 .Op Fl t Ar rrtype
+.Op Fl V Ar verb
 .Op Fl J Ar input_file
 .Sh DESCRIPTION
-.Nm dnsdbq
-constructs and issues queries to the Farsight DNSDB and displays responses. It
-is commonly used as a production command line interface to the DNSDB API
-server.
+.Nm dnsdbqv
+constructs and issues queries to the Farsight DNSDB and displays
+responses. It is commonly used as a production command line interface
+to the DNSDB API server. Its default query type is a "lookup" query.
+As an option, it can issue a "summarize" query type.
 .Pp
 DNSDB is a database that stores and indexes both the passive DNS data
 available via Farsight Security's Security Information Exchange as well as the
@@ -221,6 +223,12 @@ is ANY-DNSSEC, which matches on DS, RRSIG, NSEC, DNSKEY, NSEC3,
 NSEC3PARAM, and DLV resource record types.
 .It Fl u Ar server_sys
 specifies the syntax of the RESTful URL, default is "dnsdb".
+.It Fl V Ar verb
+The verb to perform, what type of query, either "lookup" or
+"summarize".  The default is the "lookup" verb.  As an option, you can
+request a "summarize" verb.
+.It Fl v
+report the version of dnsdbq and exit.
 .El
 .Sh "TIMESTAMP FORMATS"
 Timestamps may be one of following forms.

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -154,7 +154,7 @@ preference to -f (batch mode) or -r, -n, or -i (query mode). This can be used
 to reprocess the output from a prior invocation which used
 .Fl j
 (-p json).  If
-inut_file is "-" then standard input (stdin) willl be read.
+input_file is "-" then standard input (stdin) will be read.
 .It Fl j
 specify newline delimited json output mode.
 .It Fl k Ar sort_keys

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -126,7 +126,8 @@ An example of how to use
 .Fl f
 is below.
 .It Fl g
-return graveled results.  Default is to return aggregated results (rocks, vs. gravel).
+return graveled results.  Default is to return aggregated results (rocks, vs. gravel).  Gravel is a feature for providing Volume Across Time.
+
 .It Fl h
 emit usage and quit.
 .It Fl I
@@ -193,7 +194,7 @@ presentation format, or a left-hand (".example.com") or right-hand
 ("www.example.") wildcard domain name. Note that left-hand wildcard queries
 are somewhat more expensive than right-hand wildcard queries.
 .It Fl O Ar offset
-to offset by #results the results returned by the query.  Cannot be negative.  The default is 0.
+to offset by #offset the results returned by the query.  This gives you incremental results transfers.  Cannot be negative.  The default is 0.
 .It Fl p Ar output_type
 select output type. Specify
 .Ic csv
@@ -223,7 +224,7 @@ specifies the syntax of the RESTful URL, default is "dnsdb".
 .It Fl V Ar verb
 The verb to perform, what type of query, either "lookup" or
 "summarize".  The default is the "lookup" verb.  As an option, you can
-request a "summarize" verb.
+request a "summarize" verb.  "summarize" gives you an estimate of result size.  At-a glance, it provides information on when a given domain name, IP address or other DNS asset was first-seen and last-seen by the global sensor network, as well as the total observation count.
 .It Fl v
 report the version of dnsdbq and exit.
 .El

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -20,7 +20,7 @@
 .Nd DNSDB query tool
 .Sh SYNOPSIS
 .Nm dnsdbq
-.Op Fl dfgmhjsShcI
+.Op Fl dfgmhjsShcIv
 .Op Fl A Ar timestamp
 .Op Fl B Ar timestamp
 .Op Fl b Ar bailiwick
@@ -39,7 +39,7 @@
 .Op Fl V Ar verb
 .Op Fl J Ar input_file
 .Sh DESCRIPTION
-.Nm dnsdbqv
+.Nm dnsdbq
 constructs and issues queries to the Farsight DNSDB and displays
 responses. It is commonly used as a production command line interface
 to the DNSDB API server. Its default query type is a "lookup" query.
@@ -103,7 +103,7 @@ Queries will be read from standard input and are expected to be be in
 one of the following formats:
 .Bl -enum -offset indent
 .It
-RRSet query:
+RRset query:
 .Ic rrset/name/NAME[/RRTYPE[/BAILIWICK]]
 .It
 Rdata (name) query:
@@ -238,10 +238,10 @@ resource record types.
 .It Fl u Ar server_sys
 specifies the syntax of the RESTful URL, default is "dnsdb".
 .It Fl V Ar verb
-The verb to perform, what type of query, either "lookup" or
+The verb to perform, i.e. the type of query, either "lookup" or
 "summarize".  The default is the "lookup" verb.  As an option, you can
-request a "summarize" verb.  "summarize" gives you an estimate of
-result size.  At-a glance, it provides information on when a given
+specify the "summarize" verb, which gives you an estimate of
+result size.  At-a-glance, it provides information on when a given
 domain name, IP address or other DNS asset was first-seen and
 last-seen by the global sensor network, as well as the total
 observation count.
@@ -259,7 +259,7 @@ negative unsigned integer : negative offset in seconds from now.
 YYYY-MM-DD [HH:MM:SS] : in absolute form, in UTC time, as DNSDB does its
 fencing using UTC time.
 .It
-%dw%dd%dh%dm%ds : the relative form with explicit labels.  Calculates offsite
+%dw%dd%dh%dm%ds : the relative form with explicit labels.  Calculates offset
 from UTC time, as DNSDB does its fencing using UTC time.
 .Pp
 .El

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -223,10 +223,18 @@ sort output in ascending key order.
 .It Fl S
 sort output in descending key order.
 .It Fl t Ar rrtype
-specify the resource record type desired.  Valid values include those
-defined in DNS RFCs, including ANY.  A special-case supported in DNSDB
-is ANY-DNSSEC, which matches on DS, RRSIG, NSEC, DNSKEY, NSEC3,
-NSEC3PARAM, and DLV resource record types.
+specify the resource record type desired.  If present, this option
+should be before any
+.Fl R ,
+.Fl r ,
+or
+.Fl n
+options.  This option is not allowed if the
+.Fl i
+option is present.  Valid values include those defined in DNS RFCs,
+including ANY.  A special-case supported in DNSDB is ANY-DNSSEC, which
+matches on DS, RRSIG, NSEC, DNSKEY, NSEC3, NSEC3PARAM, and DLV
+resource record types.
 .It Fl u Ar server_sys
 specifies the syntax of the RESTful URL, default is "dnsdb".
 .It Fl V Ar verb

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -126,8 +126,8 @@ An example of how to use
 .Fl f
 is below.
 .It Fl g
-return graveled results.  Default is to return aggregated results (rocks, vs. gravel).  Gravel is a feature for providing Volume Across Time.
-
+return graveled results.  Default is to return aggregated results (rocks,
+vs. gravel).  Gravel is a feature for providing Volume Across Time.
 .It Fl h
 emit usage and quit.
 .It Fl I
@@ -144,12 +144,13 @@ prints
 the information in a more understandable textual form, including converting
 any epoch integer times into UTC formatted times.
 .It Fl i Ar ip
-specify rdata ip ("right-hand side") query.
-The value is one of an IPv4 address, an IPv6 address, an IPv4 network with prefix length, an IPv4 address range,
-or an IPv6 network with prefix length. If a network lookup is being performed,
-the delimiter between network address and prefix length is a single comma (",")
-character rather than the usual slash ("/") character to avoid clashing with
-the HTTP URI path name separator.  Examples are below.
+specify rdata ip ("right-hand side") query.  The value is one of an
+IPv4 address, an IPv6 address, an IPv4 network with prefix length, an
+IPv4 address range, or an IPv6 network with prefix length. If a
+network lookup is being performed, the delimiter between network
+address and prefix length is a single comma (",") character rather
+than the usual slash ("/") character to avoid clashing with the HTTP
+URI path name separator.  Examples are below.
 .It Fl J Ar input_file
 opens input_file and reads newline-separated JSON objects therefrom, in
 preference to -f (batch mode) or -r, -n, or -i (query mode). This can be used
@@ -180,7 +181,12 @@ output limit defaults to the
 .Fl l
 limit's value.
 .It Fl M Ar max_count
-for the summarize verb, stops summarizing when the count reaches that max_count, which must be a positive integer.  The resulting total count may exceed max_count as it will include the entire count from the last rrset examined.  The default is to not constrain the maximum count.  The number of rrsets summarized is also limited by the query_limit.
+for the summarize verb, stops summarizing when the count reaches that
+max_count, which must be a positive integer.  The resulting total
+count may exceed max_count as it will include the entire count from
+the last rrset examined.  The default is to not constrain the maximum
+count.  The number of rrsets summarized is also limited by the
+query_limit.
 .It Fl m
 used only with
 .Fl f ,
@@ -194,7 +200,9 @@ presentation format, or a left-hand (".example.com") or right-hand
 ("www.example.") wildcard domain name. Note that left-hand wildcard queries
 are somewhat more expensive than right-hand wildcard queries.
 .It Fl O Ar offset
-to offset by #offset the results returned by the query.  This gives you incremental results transfers.  Cannot be negative.  The default is 0.
+to offset by #offset the results returned by the query.  
+This gives you incremental results transfers.
+Cannot be negative.  The default is 0.
 .It Fl p Ar output_type
 select output type. Specify
 .Ic csv
@@ -224,7 +232,11 @@ specifies the syntax of the RESTful URL, default is "dnsdb".
 .It Fl V Ar verb
 The verb to perform, what type of query, either "lookup" or
 "summarize".  The default is the "lookup" verb.  As an option, you can
-request a "summarize" verb.  "summarize" gives you an estimate of result size.  At-a glance, it provides information on when a given domain name, IP address or other DNS asset was first-seen and last-seen by the global sensor network, as well as the total observation count.
+request a "summarize" verb.  "summarize" gives you an estimate of
+result size.  At-a glance, it provides information on when a given
+domain name, IP address or other DNS asset was first-seen and
+last-seen by the global sensor network, as well as the total
+observation count.
 .It Fl v
 report the version of dnsdbq and exit.
 .El

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -30,6 +30,7 @@
 .Op Fl u Ar server_sys
 .Op Fl n Ar name
 .Op Fl k Ar sort_keys
+.Op Fl M Ar max_count
 .Op Fl P Ar page
 .Op Fl p Ar output_type
 .Op Fl R Ar raw_rdata
@@ -177,6 +178,8 @@ The
 output limit defaults to the
 .Fl l
 limit's value.
+.It Fl M Ar max_count
+for the summarize verb, stops summarizing when the count reaches that max_count, which must be a positive integer.  The resulting total count may exceed max_count as it will include the entire count from the last rrset examined.  The default is to not constrain the maximum count.  The number of rrsets summarized is also limited by the query_limit.
 .It Fl m
 used only with
 .Fl f ,

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -31,7 +31,7 @@
 .Op Fl n Ar name
 .Op Fl k Ar sort_keys
 .Op Fl M Ar max_count
-.Op Fl P Ar page
+.Op Fl O Ar offset
 .Op Fl p Ar output_type
 .Op Fl R Ar raw_rdata
 .Op Fl r Ar rdata
@@ -192,14 +192,8 @@ name ("right-hand side") query.  The value is a DNS domain name in
 presentation format, or a left-hand (".example.com") or right-hand
 ("www.example.") wildcard domain name. Note that left-hand wildcard queries
 are somewhat more expensive than right-hand wildcard queries.
-.It Fl P Ar page_number
-query for the specified page of results, where a page is a
-.Fl l
-limit's worth of results.  If
-.Fl P
-is specified then
-.Fl l
-must also be specified, with a non-zero limit.
+.It Fl O Ar offset
+to offset by #results the results returned by the query.  Cannot be negative.  The default is 0.
 .It Fl p Ar output_type
 select output type. Specify
 .Ic csv
@@ -326,11 +320,6 @@ $ head -1 batch-output.json | jq .
     "ns2.wikimedia.org."
   ]
 }
-.Ed
-.Pp
-Query for the second page of results where each page is 1000 rows
-.Bd -literal -offset 4n
-$ dnsdbq -P 2 -l 1000 -r ...
 .Ed
 .Sh FILES
 .Ic ~/.isc-dnsdb-query.conf ,


### PR DESCRIPTION
  * Added -V verb flag, which defaults to the classic "lookup" verb, but also supports the new summarize flag.
  * Logic change: if -b or -t are specified then -r cannot contain a slash.
  * Document and add Warning: -t option should be before the -R, -r, or -n options.
  * Use strtol instead of atol for integers that might be very large.
  * Pretty-print offset_max value from a rate_limit call.
  * Add "-M max_count" flag to control stopping a summarize upon reaching that max_count.
  * Handle large offset values without going negative.
  * Improved -h display: Sorted the expanded options.  More uniform formatting.
  * Validate that a verb is supported by a pDNS system.  Improve circl path validation.
  * Add -O offset.
  * Use -u on sort to prevent duplicate answers when making multiple upst<E2><80><A6> (#68).
  * Add -g flag to display unaggregated results by adding &aggr=f flag in query URL (#65).
  * Support skip feature with new -P page_number option.  Improve man page formating.
  * Added instructions to add the APIKEY to the configuration file (#67).
  * Added -v command to display the version.
  * Updated copyright year.
