### PR TITLE
fix no-newline-eof bug in -f for jonas; add -f -f support (verbose ba…

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -1525,8 +1525,6 @@ launch_one(writer_t writer, char *url) {
 	if (res != CURLM_OK) {
 		fprintf(stderr, "curl_multi_add_handle() failed: %s\n",
 			curl_multi_strerror(res));
-		writer_fini(writer);
-		writer = NULL;
 		my_exit(1, NULL);
 	}
 }

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -943,8 +943,8 @@ my_panic(const char *s) {
 
 /* parse a base 10 long value.	Return true if ok, else return false.
  */
-static bool parse_long(const char *in, long *out)
-{
+static bool
+parse_long(const char *in, long *out) {
 	char *ep;
 	long result = strtol(in, &ep, 10);
 

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -311,8 +311,8 @@ static int debuglev = 0;
 static enum { no_sort = 0, normal_sort, reverse_sort } sorted = no_sort;
 static int curl_cleanup_needed = 0;
 static present_t pres = present_text;
-static int query_limit = -1;	/* -1 means not set on command line */
-static int output_limit = 0;
+static int query_limit = -1;	/* -1 means not set on command line. */
+static int output_limit = -1;	/* -1 means not set on command line. */
 static long offset = 0;
 static long max_count = 0;
 static CURLM *multi = NULL;
@@ -658,15 +658,8 @@ main(int argc, char *argv[]) {
 		escape(&bailiwick);
 	if (prefix_length != NULL)
 		escape(&prefix_length);
-	if (output_limit == 0) {
-		/* If not set, default to whatever limit has, unless limit is
-		 *  0 or -1, in which case use a really big integer.
-		 */
-		if (query_limit == 0 || query_limit == -1)
-			output_limit = INT32_MAX;
-		else
-			output_limit = query_limit;
-	}
+	if (output_limit == -1 && query_limit != -1 && !merge)
+		output_limit = query_limit;
 
 	/* optionally dump program options as interpreted. */
 	if (debuglev > 0) {
@@ -691,7 +684,7 @@ main(int argc, char *argv[]) {
 		}
 		if (query_limit != -1)
 			fprintf(stderr, "query_limit = %d\n", query_limit);
-		if (output_limit != 0)
+		if (output_limit != -1)
 			fprintf(stderr, "output_limit = %d\n", output_limit);
 		fprintf(stderr, "batching=%d, merge=%d\n",
 			(int)batching, merge);
@@ -1810,7 +1803,7 @@ writer_func(char *ptr, size_t size, size_t nmemb, void *blob) {
 		}
 
 		if (sorted == no_sort &&
-		    output_limit != 0 &&
+		    output_limit != -1 &&
 		    reader->writer->count >= output_limit)
 		{
 			if (debuglev > 2)
@@ -2045,7 +2038,7 @@ writer_fini(writer_t writer) {
 			 * this is nec'y to avoid SIGPIPE from sort if we were
 			 * to close its stdout pipe without emptying it first.
 			 */
-			if (output_limit != 0 && count >= output_limit)
+			if (output_limit != -1 && count >= output_limit)
 				continue;
 
 			char *nl, *linep;

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -89,37 +89,37 @@ typedef struct rateval *rateval_t;
 typedef const struct rateval *rateval_ct;
 
 struct reader {
-	struct reader		*next;
-	struct writer		*writer;
-	CURL			*easy;
-	struct curl_slist	*hdrs;
-	char			*url;
-	char			*buf;
-	size_t			len;
-	long			rcode;
-	bool			once;
+	struct reader	*next;
+	struct writer	*writer;
+	CURL		*easy;
+	struct curl_slist  *hdrs;
+	char		*url;
+	char		*buf;
+	size_t		len;
+	long		rcode;
+	bool		once;
 };
 typedef struct reader *reader_t;
 
 struct writer {
-	struct writer		*next;
-	struct reader		*readers;
-	u_long			after;
-	u_long			before;
-	FILE			*sort_stdin;
-	FILE			*sort_stdout;
-	pid_t			sort_pid;
-	int			count;
+	struct writer	*next;
+	struct reader	*readers;
+	u_long		after;
+	u_long		before;
+	FILE		*sort_stdin;
+	FILE		*sort_stdout;
+	pid_t		sort_pid;
+	int		count;
 };
 typedef struct writer *writer_t;
 
 struct verb {
-	const char  *cmd_opt_val;
-	const char  *url_fragment;
+	const char	*cmd_opt_val;
+	const char	*url_fragment;
 	/* validate_cmd_opts can review the command line options and exit
 	 * if some verb-specific command line option constraint is not met.
 	 */
-	void	   (*validate_cmd_opts)(void);
+	void		(*validate_cmd_opts)(void);
 };
 typedef const struct verb *verb_t;
 

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -37,6 +37,7 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -97,7 +98,6 @@ struct reader {
 	char		*buf;
 	size_t		len;
 	long		rcode;
-	bool		once;
 };
 typedef struct reader *reader_t;
 
@@ -113,6 +113,7 @@ struct writer {
 	int		count;
 	char		*status;
 	char		*message;
+	bool		once;
 };
 typedef struct writer *writer_t;
 
@@ -1808,7 +1809,7 @@ writer_func(char *ptr, size_t size, size_t nmemb, void *blob) {
 			if (newline != NULL)
 				*newline = '\0';
 
-			if (!reader->once) {
+			if (!reader->writer->once) {
 				writer_status(reader->writer,
 					      sys->status(reader),
 					      message);
@@ -1823,7 +1824,7 @@ writer_func(char *ptr, size_t size, size_t nmemb, void *blob) {
 						program_name, reader->rcode,
 						url);
 				}
-				reader->once = true;
+				reader->writer->once = true;
 			}
 			if (!quiet)
 				fprintf(stderr, "%s: libcurl: [%s]\n",

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -120,13 +120,6 @@ Rdata (raw) query:
 In batch lookup mode, each answer will be succeeded by a -- marker, so that
 programmatic users will know when it is safe to send the next lookup, or if
 lookups are pipelined, to know when one answer has ended and another begun.
-If two
-.Fl f
-options are given, then each answer will also be preceded by a ++ marker
-giving the query string (as read from the batch input) in order to identify
-each answer when a very large batch input is given. The ++ and -- markers
-are not valid JSON, CSV, or DNS (text) format, so caution is required.
-.Pp
 This option cannot be mixed with
 .Fl n ,
 .Fl r ,
@@ -135,6 +128,15 @@ or
 .Fl i .
 See the EXAMPLES section for more information on how to use
 .Fl f .
+.Pp
+If two
+.Fl f
+options are given, then each answer will also be preceded by a ++ marker
+giving the query string (as read from the batch input) in order to identify
+each answer when a very large batch input is given, and the -- marker will
+include an error/noerror indicator and a short message describing the outcome.
+The ++ and -- markers are not valid JSON, CSV, or DNS (text) format, so
+caution is required.
 .It Fl g
 return graveled results.  Default is to return aggregated results (rocks,
 vs. gravel).  Gravel is a feature for providing Volume Across Time.

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -81,12 +81,12 @@ or
 .Bl -tag -width 3n
 .It Fl A Ar timestamp
 Specify a "time_first_after" timestamp. Only results first seen by the
-Farsight sensor network on or after this date will be emitted. See below for
-timestamp formats and examples.
+Farsight sensor network on or after this date will be emitted.
+See the TIMESTAMP FORMATS section for more information about this.
 .It Fl B Ar timestamp
 Specify a "time_first_before" timestamp. Only results first seen by the
-Farsight sensor network on or before this date will be emitted. See below for
-timestamp formats and examples.
+Farsight sensor network on or before this date will be emitted.
+See the TIMESTAMP FORMATS section for more information about this.
 .It Fl b Ar bailiwick
 specify bailiwick (only valid with
 .Fl r
@@ -117,15 +117,24 @@ Rdata (raw) query:
 .Ic rdata/raw/HEX-PAIRS[/RRTYPE]
 .El
 .Pp
+In batch lookup mode, each answer will be succeeded by a -- marker, so that
+programmatic users will know when it is safe to send the next lookup, or if
+lookups are pipelined, to know when one answer has ended and another begun.
+If two
+.Fl f
+options are given, then each answer will also be preceded by a ++ marker
+giving the query string (as read from the batch input) in order to identify
+each answer when a very large batch input is given. The ++ and -- markers
+are not valid JSON, CSV, or DNS (text) format, so caution is required.
+.Pp
 This option cannot be mixed with
 .Fl n ,
 .Fl r ,
 .Fl R ,
 or
 .Fl i .
-An example of how to use
-.Fl f
-is below.
+See the EXAMPLES section for more information on how to use
+.Fl f .
 .It Fl g
 return graveled results.  Default is to return aggregated results (rocks,
 vs. gravel).  Gravel is a feature for providing Volume Across Time.
@@ -152,7 +161,8 @@ IPv4 address range, or an IPv6 network with prefix length. If a
 network lookup is being performed, the delimiter between network
 address and prefix length is a single comma (",") character rather
 than the usual slash ("/") character to avoid clashing with the HTTP
-URI path name separator.  Examples are below.
+URI path name separator.  See EXAMPLES section for more information
+about separator substitution rules.
 .It Fl J Ar input_file
 opens input_file and reads newline-separated JSON objects therefrom, in
 preference to -f (batch mode) or -r, -n, or -i (query mode). This can be used
@@ -193,7 +203,9 @@ query_limit.
 used only with
 .Fl f ,
 this causes all output to be merged rather than serialized, and causes up
-to ten (10) API jobs to execute in parallel.
+to ten (10) API queries to execute in parallel. In this mode there will be no
+"--" marker after each parallel query completes, and the combined output of
+all queries is what will be subject to sorting, if any.
 .It Fl N Ar raw-name
 specify raw
 .Ic rdata

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -187,11 +187,15 @@ server may use its default limit.
 .It Fl L Ar output_limit
 clamps the number of responses output to
 .Ic output_limit .
-The
+If unset, and if batch and merge modes have not been selected with the
+.Fl f
+and
+.Fl m
+options, then the
 .Fl L
 output limit defaults to the
 .Fl l
-limit's value.
+limit's value. Otherwise the default is no output limit.
 .It Fl M Ar max_count
 for the summarize verb, stops summarizing when the count reaches that
 max_count, which must be a positive integer.  The resulting total


### PR DESCRIPTION
this adds a ++ indicator to the front of each answer in -f mode, enabled by saying -f -f.

-f -m has no framing, since outputs are merged at newline level. -f -f m is not supported (yet.)

there's also a bug fix here, to permit batch files that don't have a newline before EOF.