### PR TITLE
Pprint info json

### DIFF
--- a/pdns_dnsdb.c
+++ b/pdns_dnsdb.c
@@ -345,7 +345,8 @@ print_burstrate(const char *key,
 
 /* pprint_json -- pretty-print a JSON buffer after validation.
  */
-static bool pprint_json(const char *buf, size_t len, FILE *outf) {
+static bool
+pprint_json(const char *buf, size_t len, FILE *outf) {
 	json_t	*js;
 	json_error_t error;
 


### PR DESCRIPTION
Instead of just writing info "json" block directly to stdout, convert it to JSON and then json_dump it.  Removes the implicit requirement that the "json" block we receive be nicely formatted.

