### PR TITLE
Query parameters were not copied into the query struct. 

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -113,7 +113,7 @@ static size_t ideal_buffer;
 int
 main(int argc, char *argv[]) {
 	struct qdesc qd = { .mode = no_mode };
-	struct qparam qp = empty;
+	struct qparam qp = qparam_empty;
 	bool info = false;
 	int json_fd = -1;
 	const char *msg;
@@ -565,7 +565,8 @@ my_exit(int code) {
 	unmake_curl();
 
 	/* globals which may have been initialized, are to be freed. */
-	psys->destroy();
+	if (psys != NULL)
+		psys->destroy();
 
 	/* sort key specifications and computations, are to be freed. */
 	sort_destroy();
@@ -1289,6 +1290,7 @@ query_launcher(qdesc_ct qdp, qparam_ct qpp, writer_t writer) {
 
 	CREATE(query, sizeof(struct query));
 	query->writer = writer;
+	query->params = *qpp;
 	writer = NULL;
 	query->next = query->writer->queries;
 	query->writer->queries = query;

--- a/globals.h
+++ b/globals.h
@@ -37,7 +37,7 @@ EXTERN	const char *program_name	INIT(NULL);
 EXTERN	const char path_sort[]		INIT("/usr/bin/sort");
 EXTERN	const char json_header[]	INIT("Accept: application/json");
 EXTERN	const char env_time_fmt[]	INIT("DNSDBQ_TIME_FORMAT");
-EXTERN	struct qparam empty INIT({ .query_limit = -1L, .output_limit = -1L });
+EXTERN	struct qparam qparam_empty INIT({ .query_limit = -1L, .output_limit = -1L });
 EXTERN	verb_ct pverb			INIT(NULL);
 EXTERN	pdns_system_ct psys		INIT(NULL);
 EXTERN	int debug_level			INIT(0);

--- a/pdns_dnsdb.c
+++ b/pdns_dnsdb.c
@@ -230,7 +230,7 @@ dnsdb_info_req(void) {
 	DEBUG(1, true, "dnsdb_info_req()\n");
 
 	/* start a writer, which might be format functions, or POSIX sort. */
-	writer = writer_init(empty.output_limit);
+	writer = writer_init(qparam_empty.output_limit);
 
 	/* create a rump query. */
 	CREATE(query, sizeof(struct query));
@@ -240,7 +240,7 @@ dnsdb_info_req(void) {
 	writer->queries = query;
 
 	/* start a status fetch. */
-	create_fetch(query, dnsdb_url(query->command, NULL, &empty));
+	create_fetch(query, dnsdb_url(query->command, NULL, &qparam_empty));
 
 	/* run all jobs to completion. */
 	io_engine(0);


### PR DESCRIPTION
 Test for null psys before destroying it.  Rename variable for understandability