### PR TITLE
remove undeclared variable

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -1158,7 +1158,6 @@ batch_options(const char *optstr, qparam_t options, qparam_ct dflt) {
 		optind = 0;
 #else
 		optind = 1;
-		optreset = 1;
 #endif
 		while ((ch = getopt((int)(opt - opts), opts, QPARAM_GETOPT))
 		       != -1)

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -1154,10 +1154,21 @@ batch_options(const char *optstr, qparam_t options, qparam_ct dflt) {
 		*options = *dflt;
 	} else {
 		/* use getopt() to parse the cracked array. */
-#ifdef linux
+#if defined __GLIBC__
+        	/* glibc needs to have optind set to 0 instead of the "traditional 
+           	 * value" of 1.
+		 */
 		optind = 0;
 #else
+        	/* 1 is the value that optind should be initialized to according to
+           	 * IEEE Std 1003.1.
+		 */
 		optind = 1;
+#if defined __FreeBSD__ || defined __OpenBSD__ || defined __NetBSD__ || \
+	defined __APPLE__ || defined __DragonFly__
+        	/* BSD-like libc also needs to have optreset set to 1 */
+		optreset = 1;
+#endif /*BSD*/
 #endif
 		while ((ch = getopt((int)(opt - opts), opts, QPARAM_GETOPT))
 		       != -1)


### PR DESCRIPTION
In the case of non-Linux systems, a build will fail because of an undeclared variable (`optreset`). This PR removes the reference to that undeclared variable to facilitate building on all supported architectures. At least in Debian it now also builds on the kFreeBSD- and Hurd-based variants (https://buildd.debian.org/status/package.php?p=dnsdbq).