### PR TITLE
when adding O: to QPARAM_OPTS, it has to be removed from the other getopt options

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -136,7 +136,7 @@ main(int argc, char *argv[]) {
 
 	/* process the command line options. */
 	while ((ch = getopt(argc, argv,
-			    "R:r:N:n:i:M:u:p:t:b:k:J:O:V:"
+			    "R:r:N:n:i:M:u:p:t:b:k:J:V:"
 			    "dfhIjmqSsUv8" QPARAM_GETOPT))
 	       != -1)
 	{


### PR DESCRIPTION
This is a stray branch.  It looks fine to me to merge.
