### PR TITLE
Add support for DNSDB API version 2 to dnsdbq.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CWARN   +=-Werror
 # warning about bad indentation, only for clang 6.x+
 #CWARN   +=-Werror=misleading-indentation
 
-CDEFS = -DWANT_PDNS_DNSDB=1 -DWANT_PDNS_CIRCL=1
+CDEFS = -DWANT_PDNS_DNSDB=1 -DWANT_PDNS_DNSDB2=1 -DWANT_PDNS_CIRCL=1
 CGPROF =
 CDEBUG = -g
 CFLAGS += $(CGPROF) $(CDEBUG) $(CWARN) $(CDEFS)

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -49,7 +49,7 @@
 #include "defs.h"
 #include "netio.h"
 #include "pdns.h"
-#if WANT_PDNS_DNSDB
+#if WANT_PDNS_DNSDB || WANT_PDNS_DNSDB2
 #include "pdns_dnsdb.h"
 #endif
 #if WANT_PDNS_CIRCL
@@ -684,7 +684,12 @@ help(void) {
 	     "use -8 to allow arbitrary 8-bit values in -r and -n arguments");
 
 	puts("for -u, system must be one of:");
+#if WANT_PDNS_DNSDB
 	puts("\tdnsdb");
+#endif
+#if WANT_PDNS_DNSDB2
+	puts("\tdnsdb2");
+#endif
 #if WANT_PDNS_CIRCL
 	puts("\tcircl");
 #endif
@@ -704,6 +709,12 @@ pick_system(const char *name) {
 #if WANT_PDNS_DNSDB
 	if (strcmp(name, "dnsdb") == 0)
 		return pdns_dnsdb();
+#endif
+#if WANT_PDNS_DNSDB2
+	if (strcmp(name, "dnsdb2") == 0) {
+		encap = encap_saf;
+		return pdns_dnsdb2();
+	}
 #endif
 #if WANT_PDNS_CIRCL
 	if (strcmp(name, "circl") == 0)
@@ -940,6 +951,10 @@ read_configs(void) {
 			     "echo dnsdb apikey $APIKEY;"
 			     "echo dnsdb server $DNSDB_SERVER;"
 #endif
+#if WANT_PDNS_DNSDB2
+			     "echo dnsdb2 apikey $APIKEY;"
+			     "echo dnsdb2 server $DNSDB_SERVER;"
+#endif
 #if WANT_PDNS_CIRCL
 			     "echo circl apikey $CIRCL_AUTH;"
 			     "echo circl server $CIRCL_SERVER;"
@@ -1053,6 +1068,10 @@ do_batch(FILE *f, qparam_ct qpp) {
 		nl = strchr(command, '\n');
 		if (nl != NULL)
 			*nl = '\0';
+
+		/* allow # as a comment syntax */
+		if (command[0] == '#')
+			continue;
 
 		DEBUG(1, true, "do_batch(%s)\n", command);
 

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -41,18 +41,19 @@
 .Op Fl V Ar verb
 .Sh DESCRIPTION
 .Nm dnsdbq
-constructs and issues queries to the Farsight DNSDB and displays
-responses. It is commonly used as a production command line interface
-to the DNSDB API server. Its default query type is a "lookup" query.
-As an option, it can issue a "summarize" query type.
+constructs and issues queries to Passive DNS systems which return
+data in the IETF Passive DNS Common Output Format. Farsight Security's
+DNSDB is one such system.
+.Nm dnsdbq
+displays responses in various formats.  It is commonly used as a
+production command line interface to such systems.
 .Pp
-DNSDB is a database that stores and indexes both the passive DNS data
-available via Farsight Security's Security Information Exchange as well as the
-authoritative DNS data that various zone operators make available. DNSDB makes
-it easy to search for individual DNS RRsets and provides additional metadata
-for search results such as first seen and last seen timestamps as well as the
-DNS bailiwick associated with an RRset. DNSDB also has the ability to perform
-inverse or rdata searches.
+Its default query type is a "lookup" query.  As an option, it can
+issue a "summarize" query type.
+.Pp
+Farsight Security's DNSDB system implements both APIv1 and APIv2 interfaces.
+APIv1 is accessed by specifying system "dnsdb."  APIv2 is accessed by
+specifying system "dnsdb2".
 .Pp
 You'll need to get an API key from Farsight to use
 .Ic dnsdbq
@@ -106,7 +107,7 @@ mode).
 enable debug mode.  Repeat for more debug output.
 .It Fl f
 specify batch lookup mode allowing one or more queries to be performed.
-Queries will be read from standard input and are expected to be be in
+Queries will be read from standard input and are expected to be in
 one of the following formats:
 .Bl -dash -offset indent
 .It
@@ -140,6 +141,8 @@ Where
 $OPTIONS alone on a line allows command line options to be changed mid-batch.
 If no options are given, the query parameters will be reset to those given
 on the command line, if any, or else to defaults.
+.Pp
+A line starting with a # will be ignored as a comment.
 .Pp
 Any internal slash (/) or comma (,) characters within the search names
 of a batch entry must be URL-encoded (for example, %2F or %2C).
@@ -503,7 +506,7 @@ enable access to a passive DNS system compatible with the CIRCL.LU system.
 .It Ev DNSDBQ_SYSTEM
 contains the default value for the
 .Ar u
-option described above. Can be "dnsdb" or "circl". If unset,
+option described above. Can be "dnsdb", "dnsdb2", or "circl". If unset,
 .Nm dnsdbq
 will probe for any configured system.
 .El

--- a/globals.h
+++ b/globals.h
@@ -32,10 +32,11 @@ extern const struct verb verbs[];
 #endif
 
 EXTERN	const char id_swclient[]	INIT("dnsdbq");
-EXTERN	const char id_version[]		INIT("2.2.2");
+EXTERN	const char id_version[]		INIT("2.3.0");
 EXTERN	const char *program_name	INIT(NULL);
 EXTERN	const char path_sort[]		INIT("/usr/bin/sort");
 EXTERN	const char json_header[]	INIT("Accept: application/json");
+EXTERN	const char jsonl_header[]	INIT("Accept: application/x-ndjson");
 EXTERN	const char env_time_fmt[]	INIT("DNSDBQ_TIME_FORMAT");
 EXTERN	const char status_noerror[]	INIT("NOERROR");
 EXTERN	const char status_error[]	INIT("ERROR");
@@ -52,6 +53,7 @@ EXTERN	sort_e sorting			INIT(no_sort);
 EXTERN	batch_e batching		INIT(batch_none);
 EXTERN	present_e presentation		INIT(pres_text);
 EXTERN	present_t presenter		INIT(NULL);
+EXTERN	encap_e encap			INIT(encap_bare);
 EXTERN	struct timeval startup_time	INIT({});
 EXTERN	int exit_code			INIT(0);
 EXTERN	long curl_ipresolve		INIT(CURL_IPRESOLVE_WHATEVER);

--- a/netio.h
+++ b/netio.h
@@ -20,6 +20,19 @@
 #include <stdbool.h>
 #include <curl/curl.h>
 
+/* encapsulation protocol.  original DNBDB APIv1 and CIRCL use encap_bare. */
+typedef enum { encap_bare = 0, encap_saf } encap_e;
+
+/* official SAF condition values, plus sc_init, sc_we_limited, and sc_missing.
+ */
+typedef enum {
+	sc_init = 0,	 /* initial condition */
+	/* official */
+	sc_begin, sc_ongoing, sc_succeeded, sc_limited, sc_failed,
+	sc_we_limited,	 /* we noticed we hit the output limit */
+	sc_missing	 /* cond was missing at end of input stream */
+} saf_cond_e;
+
 /* search parameters, per query and globally. */
 struct qparam {
 	u_long		after;
@@ -58,6 +71,8 @@ struct query {
 	char		*status;
 	char		*message;
 	bool		hdr_sent;
+	saf_cond_e	saf_cond;
+	char		*saf_msg;
 };
 typedef struct query *query_t;
 

--- a/pdns_dnsdb.h
+++ b/pdns_dnsdb.h
@@ -21,4 +21,8 @@
 pdns_system_ct pdns_dnsdb(void);
 #endif
 
+#if WANT_PDNS_DNSDB2
+pdns_system_ct pdns_dnsdb2(void);
+#endif
+
 #endif /*PDNS_DNSDB_H_INCLUDED*/


### PR DESCRIPTION
Requires using an updated DNSDB API server.

To use the new features, add the followning line the ~/.dnsdb-query.conf file:
    DNSDBQ_SYSTEM=dnsdb2
or add the command-line option
    -u dnsdb2

If you leave out that line, that command-line option, or use
    DNSDBQ_SYSTEM=dnsdb
then dnsdbq will function as it previously did with DNSDB API version 1.