### PR TITLE
For an info command, do not output "Query status: NOERROR (no results found for query.)" when successful

### DIFF
--- a/netio.c
+++ b/netio.c
@@ -718,6 +718,7 @@ io_drain(void) {
 			/* record emptiness as status if nothing else. */
 			if (encap == encap_saf &&
 			    query->writer != NULL &&
+			    !query->writer->info &&
 			    query->writer->count == 0 &&
 			    query->status == NULL)
 			{


### PR DESCRIPTION
still does print an error message if applicable, such as "Query status: ERROR (Error: Bad API key)"