### PR TITLE
Make sure CURL_AT_LEAST_VERSION is defined before using it.

### DIFF
--- a/netio.c
+++ b/netio.c
@@ -123,9 +123,12 @@ create_fetch(query_t query, char *url) {
 	curl_easy_setopt(fetch->easy, CURLOPT_WRITEFUNCTION, writer_func);
 	curl_easy_setopt(fetch->easy, CURLOPT_WRITEDATA, fetch);
 	curl_easy_setopt(fetch->easy, CURLOPT_PRIVATE, fetch);
+#ifdef CURL_AT_LEAST_VERSION
+/* If CURL_AT_LEAST_VERSION is not defined then the curl is probably too old */
 #if CURL_AT_LEAST_VERSION(7,42,0)
 	/* do not allow curl to swallow /./ and /../ in our URLs */
 	curl_easy_setopt(fetch->easy, CURLOPT_PATH_AS_IS, 1L);
+#endif
 #endif /* CURL_AT_LEAST_VERSION */
 	if (debug_level >= 3)
 		curl_easy_setopt(fetch->easy, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
We need it for a feature test for a feature from 7.42.0.
CURL_AT_LEAST_VERSION was introduced in 7.43.0.
Therefore, if we build against 7.42.0 then we won't use the CURLOPT_PATH_AS_IS feature.
This is a small bug but 7.42.0 is from 2015.