### PR TITLE
Test for native __CYGWIN__ macro to disable AS info feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,7 @@ CWARN   +=-Werror
 # warning about bad indentation, only for clang 6.x+
 #CWARN   +=-Werror=misleading-indentation
 
-# cygwin requires -DCRIPPLED_LIBC
 CDEFS = -DWANT_PDNS_DNSDB=1 -DWANT_PDNS_CIRCL=1
-#CDEFS = -DWANT_PDNS_DNSDB=1 -DWANT_PDNS_CIRCL=1 -DCRIPPLED_LIBC
 CGPROF =
 CDEBUG = -g -O3
 CFLAGS += $(CGPROF) $(CDEBUG) $(CWARN) $(CDEFS)

--- a/asinfo.c
+++ b/asinfo.c
@@ -1,4 +1,4 @@
-#ifndef CRIPPLED_LIBC
+#ifndef __CYGWIN__
 /*
  * Copyright (c) 2014-2020 by Farsight Security, Inc.
  *
@@ -13,6 +13,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/* Note that cygwin has a crippled libresolv that does not
+ * include the not so recent ns_initparse() function, etc.
+ * This AS info functionality is thus not available
+ * in cygwin.
  */
 
 /* external. */
@@ -323,4 +329,4 @@ keep_best(char **asnum, char **cidr, char *new_asnum, char *new_cidr) {
 	}
 	return NULL;
 }
-#endif /*CRIPPLED_LIBC*/
+#endif /*__CYGWIN__*/

--- a/asinfo.h
+++ b/asinfo.h
@@ -19,7 +19,7 @@
 
 #include <stdbool.h>
 
-#ifndef CRIPPLED_LIBC
+#ifndef __CYGWIN__
 const char *
 asinfo_from_rr(const char *rrtype, const char *rdata, char **asn, char **cidr);
 #endif

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -428,7 +428,7 @@ main(int argc, char *argv[]) {
 	}
 
 	if (asinfo_lookup) {
-#ifdef CRIPPLED_LIBC
+#ifdef  __CYGWIN__
 		usage("the -a option requires a modern functional C library.");
 #else
 		if (!asinfo_domain_exists(asinfo_domain)) {
@@ -615,7 +615,7 @@ my_exit(int code) {
 	/* sort key specifications and computations, are to be freed. */
 	sort_destroy();
 
-#ifndef CRIPPLED_LIBC
+#ifndef __CYGWIN__
 	/* asinfo logic has an internal DNS resolver context. */
 	asinfo_shutdown();
 #endif

--- a/pdns.c
+++ b/pdns.c
@@ -31,7 +31,7 @@ static void present_text_line(const char *, const char *, const char *);
 static void present_csv_line(pdns_tuple_ct, const char *);
 static json_t *annotate_json(pdns_tuple_ct);
 static json_t *annotate_one(json_t *, const char *, const char *, json_t *);
-#ifndef CRIPPLED_LIBC
+#ifndef  __CYGWIN__
 static json_t *annotate_asinfo(const char *, const char *);
 #endif
 
@@ -126,7 +126,7 @@ present_text_line(const char *rrname, const char *rrtype, const char *rdata) {
 	char *asnum = NULL, *cidr = NULL, *comment = NULL;
 	const char *result = NULL;
 
-#ifndef CRIPPLED_LIBC
+#ifndef  __CYGWIN__
 	result = asinfo_from_rr(rrtype, rdata, &asnum, &cidr);
 #endif
 	if (result != NULL) {
@@ -254,7 +254,7 @@ annotate_json(pdns_tuple_ct tup) {
 			const char *rdata = json_string_value(rr);
 			json_t *asinfo = NULL;
 
-#ifndef CRIPPLED_LIBC
+#ifndef __CYGWIN__
 			asinfo = annotate_asinfo(tup->rrtype, rdata);
 #endif
 			if (asinfo != NULL)
@@ -264,7 +264,7 @@ annotate_json(pdns_tuple_ct tup) {
 	} else {
 		json_t *asinfo = NULL;
 
-#ifndef CRIPPLED_LIBC
+#ifndef __CYGWIN__
 		asinfo = annotate_asinfo(tup->rrtype, tup->rdata);
 #endif
 		if (asinfo != NULL)
@@ -298,7 +298,7 @@ annotate_one(json_t *anno, const char *rdata, const char *name, json_t *obj) {
 	return anno;
 }
 
-#ifndef CRIPPLED_LIBC
+#ifndef __CYGWIN__
 static json_t *
 annotate_asinfo(const char *rrtype, const char *rdata) {
 	char *asnum = NULL, *cidr = NULL;
@@ -415,7 +415,7 @@ present_csv_line(pdns_tuple_ct tup, const char *rdata) {
 		char *asnum = NULL, *cidr = NULL;
 		const char *result = NULL;
 
-#ifndef CRIPPLED_LIBC
+#ifndef __CYGWIN__
 		result = asinfo_from_rr(tup->rrtype, rdata, &asnum, &cidr);
 #endif
 		if (result != NULL) {


### PR DESCRIPTION
An alternative to CRIPPLED_LIBC is to use __CYGWIN__.
An advantage is the Makefile need not be edited to compile on cygwin.