### PR TITLE
Domainsort

### DIFF
--- a/netio.c
+++ b/netio.c
@@ -489,6 +489,7 @@ writer_fini(writer_t writer) {
 			query->fetches = fetch_next;
 		}
 		assert((query->status != NULL) == (query->message != NULL));
+		DESTROY(query->saf_msg);
 		DESTROY(query->status);
 		DESTROY(query->message);
 		DESTROY(query->command);

--- a/pdns.c
+++ b/pdns.c
@@ -677,6 +677,7 @@ tuple_make(pdns_tuple_t tup, const char *buf, size_t len) {
 		}
 
 		if (dot) {
+			/* in chomp+reverse, the dot to chomp is now leading. */
 			tup->rrname = strdup(r + dot);
 			DESTROY(r);
 		} else {

--- a/pdns.c
+++ b/pdns.c
@@ -535,7 +535,11 @@ tuple_make(pdns_tuple_t tup, const char *buf, size_t len) {
 			error.text, error.source);
 		abort();
 	}
-	DEBUG(4, true, "%s\n", json_dumps(tup->obj.main, JSON_INDENT(2)));
+	if (debug_level >= 4) {
+		char *pretty = json_dumps(tup->obj.main, JSON_INDENT(2));
+		fprintf(stderr, "debug: %s\n", pretty);
+		free(pretty);
+	}
 
 	switch (psys->encap) {
 	case encap_cof:

--- a/pdns.h
+++ b/pdns.h
@@ -29,18 +29,23 @@
  * If not using SAF encapulation, then cof_obj points to main.
  * If using SAF encapulation, then saf_cond, saf_msg, and saf_obj are
  * parsed from main and cof_obj is repointed to saf_obj.
+ *
+ * tup->obj.rrname is always original, tup->rrname is sometimes reversed.
+ * as a result, tup->rrname is always heap-allocated, even if unreversed.
  */
 struct pdns_json {
-	json_t *main, *rrname;
+	json_t *main;
 	const json_t *cof_obj, *saf_obj, *saf_cond, *saf_msg,
 		*time_first, *time_last, *zone_first, *zone_last,
-		*bailiwick, *rrtype, *rdata, *count, *num_results;
+		*bailiwick, *rrname, *rrtype, *rdata,
+		*count, *num_results;
 };
 
 struct pdns_tuple {
 	struct pdns_json  obj;
 	u_long		  time_first, time_last, zone_first, zone_last;
-	const char	 *bailiwick, *rrname, *rrtype, *rdata, *cond, *msg;
+	const char	 *bailiwick, *rrtype, *rdata, *cond, *msg;
+	char		 *rrname;
 	json_int_t	  count, num_results;
 };
 typedef struct pdns_tuple *pdns_tuple_t;

--- a/pdns.h
+++ b/pdns.h
@@ -154,6 +154,7 @@ typedef const struct qdesc *qdesc_ct;
 struct counted {
 	size_t nlabel;
 	size_t nchar;
+	size_t nalnum;
 	size_t lens[];
 };
 #define COUNTED_SIZE(nlabel) (sizeof(struct counted) + nlabel * sizeof(size_t))

--- a/pdns_dnsdb.c
+++ b/pdns_dnsdb.c
@@ -581,7 +581,11 @@ rate_tuple_make(rate_tuple_t tup, const char *buf, size_t len) {
 			error.text, error.source);
 		abort();
 	}
-	DEBUG(4, true, "%s\n", json_dumps(tup->obj.main, JSON_INDENT(2)));
+	if (debug_level >= 4) {
+		char *pretty = json_dumps(tup->obj.main, JSON_INDENT(2));
+		fprintf(stderr, "debug: %s\n", pretty);
+		free(pretty);
+	}
 
 	rate = json_object_get(tup->obj.main, "rate");
 	if (rate == NULL) {

--- a/sort.c
+++ b/sort.c
@@ -249,25 +249,27 @@ void
 sortable_dnsname(sortbuf_t buf, const char *name) {
 	struct counted *c = countoff(name, 0);
 
-	// ensure our result buffer is exactly large enough.
-	size_t new_size = buf->size + c->nchar*2 - (size_t)c->nlabel;
+	// ensure our result buffer is large enough.
+	size_t new_size = buf->size + c->nalnum*2;
 	assert(new_size != 0);
 	if (new_size != buf->size)
 		buf->base = realloc(buf->base, new_size);
 	char *p = buf->base + buf->size;
 
-	// collatable names are TLD-first, all lower case, hexified.
+	// collatable names are TLD-first, alphanumeric, lower case, hexified.
 	size_t nchar = 0;
 	for (ssize_t i = (ssize_t)(c->nlabel-1); i >= 0; i--) {
 		size_t dot = (name[c->nchar - nchar - 1] == '.');
 		ssize_t j = (ssize_t)(c->lens[i] - dot);
 		ssize_t k = (ssize_t)(c->nchar - nchar - c->lens[i]);
-		*p++ = '.';
 		for (ssize_t l = k; l < j+k; l++) {
-			static const char hex[] = "0123456789abcdef";
-			int ch = tolower(name[l]);
-			*p++ = hex[ch >> 4];
-			*p++ = hex[ch & 0xf];
+			int ch = name[l];
+			if (isalnum(ch)) {
+				static const char hex[] = "0123456789abcdef";
+				ch = tolower(ch);
+				*p++ = hex[ch >> 4];
+				*p++ = hex[ch & 0xf];
+			}
 		}
 		nchar += c->lens[i];
 	}

--- a/sort.c
+++ b/sort.c
@@ -151,9 +151,6 @@ sortable_rrname(pdns_tuple_ct tup) {
 	sortable_dnsname(&buf, json_string_value(tup->obj.rrname));
 	buf.base = realloc(buf.base, buf.size+1);
 	buf.base[buf.size++] = '\0';
-	fprintf(stderr, "sortable_rrname(%s) -> %s\n",
-		json_string_value(tup->obj.rrname),
-		buf.base);
 	return (buf.base);
 }
 


### PR DESCRIPTION
greatly simplify sortable_dnsname(), and fix an assertion there.

add nalnum to struct counted, for use by the above.

make tup->obj.rrname immutable, and have only tup->rrname subject to transforms.