### PR TITLE
clarify relationship of -c to -A/-B, in both main text and examples

### DIFF
--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -108,9 +108,14 @@ by default,
 and
 .Fl B
 (separately or together) will select partial overlaps of database tuples and
-time search criteria. To match only complete overlaps, add the -c
-("completeness") command line option (this is also known as "strict"
-mode).
+time search criteria. To match only completely bracketed tuples, add the
+.Fl c
+("completeness") flag (this is also known as "strict" mode). Can only be
+specified once, and for reasons of geometry, affects both
+.Fl A
+and
+.Fl B
+if both are specified.
 .It Fl D
 specify the data source for ASINFO/CIDR annotations, if enabled by
 .Fl a .
@@ -438,23 +443,23 @@ times to now, the value for "now" is set when dnsdbq starts.
 .Pp
 A few examples of how to use timefencing options.
 .Bd -literal -offset 4n
-# only responses after Aug 22, 2015 (midnight)
+# tuples ending after Aug 22, 2015 (midnight)
 $ dnsdbq ... -A 2015-08-22
-# only responses before Jan 22, 2013 (midnight)
+# tuples starting before Jan 22, 2013 (midnight)
 $ dnsdbq ... -B 2013-01-22
-# only responses from 2015 (midnight to midnight)
+# tuples starting or ending from 2015 (midnight to midnight)
 $ dnsdbq ... -B 2016-01-01 -A 2015-01-01
-# only responses after 2015-08-22 14:36:10
+# tuples ending after 2015-08-22 14:36:10
 $ dnsdbq ... -A "2015-08-22 14:36:10"
-# only responses from the last 60 minutes
+# tuples ending within the last 60 minutes
 $ dnsdbq ... -A "-3600"
-# only responses after "just now"
-$ dnsdbq -f ... -A "-3600"
-# batch mode with only responses after "just now", even if feeding inputs
-to dnsdbq in batch mode takes hours.
+# tuples ending after "just now"
 $ date +%s
 1485284066
 $ dnsdbq ... -A 1485284066
+# batch mode with only tuples ending within last 60 minutes,
+# even if feeding inputs to dnsdbq in batch mode takes hours.
+$ dnsdbq -f ... -A "-3600"
 .Ed
 .Sh EXAMPLES
 .Pp


### PR DESCRIPTION
     -c   by default, -A and -B (separately or together) will select partial over-
          laps of database tuples and time search criteria. To match only com-
          pletely bracketed tuples, add the -c ("completeness") flag (this is also
          known as "strict" mode). Can only be specified once, and for reasons of
          geometry, affects both -A and -B if both are specified.