### PR TITLE
minor cleanups

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -919,8 +919,8 @@ find_verb(const char *option) {
 
 	for (v = verbs; v->name != NULL; v++)
 		if (strcasecmp(option, v->name) == 0)
-			return (v);
-	return (NULL);
+			return v;
+	return NULL;
 }
 
 /* select_config -- try to find a config file in static path.
@@ -938,11 +938,11 @@ select_config(void) {
 		wordfree(&we);
 		if (access(cf, R_OK) == 0) {
 			DEBUG(1, true, "conf found: '%s'\n", cf);
-			return (cf);
+			return cf;
 		}
 		DESTROY(cf);
 	}
-	return (NULL);
+	return NULL;
 }
 
 /* do_batch -- implement "filter" mode, reading commands from a batch file.
@@ -1282,7 +1282,7 @@ makepath(mode_e mode, const char *name, const char *rrtype,
 	default:
 		abort();
 	}
-	return (command);
+	return command;
 }
 
 /* query_launcher -- fork off some curl jobs via launch() for this query.

--- a/netio.c
+++ b/netio.c
@@ -143,7 +143,7 @@ create_fetch(query_t query, char *url) {
 			program_name, curl_multi_strerror(res));
 		my_exit(1);
 	}
-	return (fetch);
+	return fetch;
 }
 
 /* fetch_reap -- reap one fetch.
@@ -228,7 +228,7 @@ writer_init(long output_limit, ps_user_t ps_user, bool meta_query) {
 
 	writer->next = writers;
 	writers = writer;
-	return (writer);
+	return writer;
 }
 
 void
@@ -333,7 +333,7 @@ writer_func(char *ptr, size_t size, size_t nmemb, void *blob) {
 			DESTROY(message);
 			fetch->buf[0] = '\0';
 			fetch->len = 0;
-			return (bytes);
+			return bytes;
 		}
 	}
 
@@ -385,7 +385,7 @@ writer_func(char *ptr, size_t size, size_t nmemb, void *blob) {
 		fetch->len = post_len;
 	}
 
-	return (bytes);
+	return bytes;
 }
 
 /* query_done -- do something with leftover buffer data when a query ends.

--- a/ns_ttl.c
+++ b/ns_ttl.c
@@ -32,8 +32,8 @@ static int fmt1(u_long t, char s, char **buf, size_t *buflen);
 
 /* Macros. */
 
-#define T(x) {if ((x) < 0) return (-1); else (void)NULL;}
-#define A(c) {if (dstlen < 2) return (-1); else *dst++ = c, *dst = '\0';}
+#define T(x) {if ((x) < 0) return -1; else (void)NULL;}
+#define A(c) {if (dstlen < 2) return -1; else *dst++ = c, *dst = '\0';}
 
 /* Public. */
 
@@ -126,11 +126,11 @@ ns_parse_ttl(const char *src, u_long *dst) {
 	} else if (!dirty)
 		goto einval;
 	*dst = ttl;
-	return (0);
+	return 0;
 
  einval:
 	errno = EINVAL;
-	return (-1);
+	return -1;
 }
 
 /* Private. */
@@ -142,9 +142,9 @@ fmt1(u_long t, char s, char **buf, size_t *buflen) {
 
 	len = (size_t) sprintf(tmp, "%lu%c", t, s);
 	if (len + 1 > *buflen)
-		return (-1);
+		return -1;
 	strcpy(*buf, tmp);
 	*buf += len;
 	*buflen -= len;
-	return (0);
+	return 0;
 }

--- a/pdns.c
+++ b/pdns.c
@@ -713,12 +713,12 @@ tuple_make(pdns_tuple_t tup, const char *buf, size_t len) {
 	}
 
 	assert(msg == NULL);
-	return (NULL);
+	return NULL;
 
  ouch:
 	assert(msg != NULL);
 	tuple_unmake(tup);
-	return (msg);
+	return msg;
 }
 
 /* tuple_unmake -- deallocate the heap storage associated with one tuple.
@@ -775,7 +775,7 @@ countoff(const char *src, size_t nlabel) {
 	} else {
 		abort();
 	}
-	return (c);
+	return c;
 }
 
 /* reverse -- put a domain name into TLD-first order.
@@ -799,7 +799,7 @@ reverse(const char *src) {
 	}
 	*p = '\0';
 	DESTROY(c);
-	return (ret);
+	return ret;
 }
 
 /* data_blob -- process one deblocked json blob as a counted string.
@@ -918,7 +918,7 @@ data_blob(query_t query, const char *buf, size_t len) {
  next:
 	tuple_unmake(&tup);
  more:
-	return (ret);
+	return ret;
 }
 
 /* pick_system -- find a named system descriptor, return t/f as to "found?"

--- a/pdns.h
+++ b/pdns.h
@@ -54,7 +54,6 @@ typedef const struct pdns_tuple *pdns_tuple_ct;
 struct pdns_fence {
 	u_long	first_after, first_before, last_after, last_before;
 };
-typedef struct pdns_fence *pdns_fence_t;
 typedef const struct pdns_fence *pdns_fence_ct;
 
 struct pdns_system {

--- a/pdns.h
+++ b/pdns.h
@@ -54,7 +54,7 @@ typedef const struct pdns_tuple *pdns_tuple_ct;
 struct pdns_fence {
 	u_long	first_after, first_before, last_after, last_before;
 };
-typedef struct pdns_fence pdns_fence_t;
+typedef struct pdns_fence *pdns_fence_t;
 typedef const struct pdns_fence *pdns_fence_ct;
 
 struct pdns_system {
@@ -68,11 +68,15 @@ struct pdns_system {
 	encap_e		encap;
 
 	/* start creating a URL corresponding to a command-path string.
-	 * first argument is the input URL path.
-	 * second is an output parameter pointing to the separator character
-	 * (? or &) that the caller should use between any further URL
-	 * parameters.  May be NULL if the caller doesn't care.
-	 * the third argument is search parameters.
+	 * First argument is the input URL path.
+	 * Second argument is an output parameter pointing to the
+	 * separator character (? or &) that the caller should use
+	 * between any further URL parameters.	May be NULL if the
+	 * caller doesn't care.
+	 * Third argument is search parameters.
+	 * Fourth argument is time fencing parameters.
+	 * Fifth argument is true if the query is a meta query, which
+	 * doesn't get regular result processing.
 	 */
 	char *		(*url)(const char *, char *, qparam_ct,
 			       pdns_fence_ct, bool);
@@ -92,11 +96,15 @@ struct pdns_system {
 
 	/* verify that the specified verb is supported by this pdns system.
 	 * Returns NULL if supported; otherwise returns a static error message.
+	 * First argument is the verb.
+	 * Second argument is search parameters.
 	 */
 	const char *	(*verb_ok)(const char *, qparam_ct);
 
-	/* set a configuration key-value pair.  Returns NULL if ok;
-	 * otherwise returns a static error message.
+	/* set a configuration key-value pair.
+	 * Returns NULL if ok; otherwise returns a static error message.
+	 * First argument is the key.
+	 * Second argument is the value.
 	 */
 	const char *	(*setval)(const char *, const char *);
 

--- a/pdns_circl.c
+++ b/pdns_circl.c
@@ -134,7 +134,7 @@ circl_url(const char *path, char *sep,
 	if (sep != NULL)
 		*sep = '?';
 
-	return (ret);
+	return ret;
 }
 
 static void
@@ -156,8 +156,8 @@ static const char *
 circl_verb_ok(const char *verb_name, qparam_ct qpp __attribute__((unused))) {
 	/* Only "lookup" is valid */
 	if (strcasecmp(verb_name, "lookup") != 0)
-		return ("the CIRCL system only understands 'lookup'");
-	return (NULL);
+		return "the CIRCL system only understands 'lookup'";
+	return NULL;
 }
 
 #endif /*WANT_PDNS_CIRCL*/

--- a/pdns_dnsdb.c
+++ b/pdns_dnsdb.c
@@ -313,7 +313,7 @@ dnsdb_url(const char *path, char *sep, qparam_ct qpp,
 	DESTROY(first_before_str);
 	DESTROY(last_after_str);
 	DESTROY(last_before_str);
-	return (ret);
+	return ret;
 }
 
 static void
@@ -409,7 +409,7 @@ dnsdb_verb_ok(const char *verb_name, qparam_ct qpp __attribute__((unused))) {
 		if (qpp->explicit_output_limit != -1)
 			return "only 'lookup' understands output limits";
 	}
-	return (NULL);
+	return NULL;
 }
 
 /*---------------------------------------------------------------- private
@@ -507,12 +507,12 @@ rateval_make(rateval_t tp, const json_t *obj, const char *key) {
 				}
 			}
 			if (!ok)
-				return ("value must be an integer "
-					"or \"n/a\" or \"unlimited\"");
+				return "value must be an integer "
+					"or \"n/a\" or \"unlimited\"";
 		}
 	}
 	*tp = rvalue;
-	return (NULL);
+	return NULL;
 }
 
 /* rate_tuple_make -- create one rate tuple object out of a JSON object.
@@ -577,12 +577,12 @@ rate_tuple_make(rate_tuple_t tup, const char *buf, size_t len) {
 		goto ouch;
 
 	assert(msg == NULL);
-	return (NULL);
+	return NULL;
 
  ouch:
 	assert(msg != NULL);
 	rate_tuple_unmake(tup);
-	return (msg);
+	return msg;
 }
 
 /* rate_tuple_unmake -- deallocate heap storage associated with a rate tuple.

--- a/sort.c
+++ b/sort.c
@@ -62,7 +62,7 @@ add_sort_key(const char *key_name) {
 	int x;
 
 	if (nkeys == MAX_KEYS)
-		return ("too many sort keys given.");
+		return "too many sort keys given.";
 	if (strcasecmp(key_name, "first") == 0)
 		key = "-k1n";
 	else if (strcasecmp(key_name, "last") == 0)
@@ -82,7 +82,7 @@ add_sort_key(const char *key_name) {
 	if (x < 0)
 		my_panic(true, "asprintf");
 	keys[nkeys++] = (struct sortkey){strdup(key_name), computed};
-	return (NULL);
+	return NULL;
 }
 
 /* find_sort_key -- return pointer to a sort key, or NULL if it's not specified
@@ -93,9 +93,9 @@ find_sort_key(const char *key_name) {
 
 	for (n = 0; n < nkeys; n++) {
 		if (strcmp(keys[n].specified, key_name) == 0)
-			return (&keys[n]);
+			return &keys[n];
 	}
-	return (NULL);
+	return NULL;
 }
 
 /* sort_destroy -- drop sort metadata from heap.
@@ -151,7 +151,7 @@ sortable_rrname(pdns_tuple_ct tup) {
 	sortable_dnsname(&buf, json_string_value(tup->obj.rrname));
 	buf.base = realloc(buf.base, buf.size+1);
 	buf.base[buf.size++] = '\0';
-	return (buf.base);
+	return buf.base;
 }
 
 /* sortable_rdata -- return a POSIX-sort-collatable rendition of RR data set.
@@ -179,7 +179,7 @@ sortable_rdata(pdns_tuple_ct tup) {
 	}
 	buf.base = realloc(buf.base, buf.size+1);
 	buf.base[buf.size++] = '\0';
-	return (buf.base);
+	return buf.base;
 }
 
 /* sortable_rdatum -- called only by sortable_rdata(), realloc and normalize.

--- a/time.c
+++ b/time.c
@@ -34,10 +34,10 @@
 int
 time_cmp(u_long a, u_long b) {
 	if (a < b)
-		return (-1);
+		return -1;
 	if (a > b)
-		return (1);
-	return (0);
+		return 1;
+	return 0;
 }
 
 /* time_str -- format one (possibly zero) timestamp (returns static string)
@@ -71,7 +71,7 @@ time_get(const char *src, u_long *dst) {
 	    ((ep = strptime(src, "%F", &tt)) != NULL && *ep == '\0'))
 	{
 		*dst = (u_long)(timegm(&tt));
-		return (1);
+		return 1;
 	}
 	ll = strtoll(src, &ep, 10);
 	if (*src != '\0' && *ep == '\0') {
@@ -80,12 +80,12 @@ time_get(const char *src, u_long *dst) {
 				(u_long)imaxabs(ll);
 		else
 			*dst = (u_long)ll;
-		return (1);
+		return 1;
 	}
 	if (ns_parse_ttl(src, &t) == 0) {
 		*dst = (u_long)startup_time.tv_sec - t;
-		return (1);
+		return 1;
 	}
-	return (0);
+	return 0;
 }
 


### PR DESCRIPTION
Improve comments in struct pdns_system.  Make one typedef more consistent.

Use return X; consistently, rather than a mix with return (X);