### PR TITLE
Pretty-print quotas information with a burst rate that includes number used in burst.

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -33,7 +33,7 @@ extern const struct verb verbs[];
 #endif
 
 EXTERN	const char id_swclient[]	INIT("dnsdbq");
-EXTERN	const char id_version[]		INIT("2.5.6");
+EXTERN	const char id_version[]		INIT("2.5.7");
 EXTERN	const char *program_name	INIT(NULL);
 EXTERN	const char path_sort[]		INIT("/usr/bin/sort");
 EXTERN	const char json_header[]	INIT("Accept: application/json");


### PR DESCRIPTION
This depends upon unreleased DNSDB updates.  Do not merge yet.


New version 2.5.6

Pretty-print quotas information with a burst rate that includes
number used in burst.
Example:
$ dnsdbq -I
rate:
	reset: n/a
	expires: 2021-12-31 00:00:00
	limit: 10000
	remaining: 9945
	results_max: 1000000
	offset_max: 3000000
	burst rate: 5 per 30 seconds, 1 used in this window