### PR TITLE
add '-p minimal', becomes V2.5.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ LIBS= $(CURLLIBS) $(JANSLIBS) -lresolv
 TOOL = dnsdbq
 TOOL_OBJ = $(TOOL).o ns_ttl.o netio.o \
 	pdns.o pdns_circl.o pdns_dnsdb.o \
-	sort.o time.o asinfo.o
+	sort.o time.o asinfo.o deduper.o
 TOOL_SRC = $(TOOL).c ns_ttl.c netio.c \
 	pdns.c pdns_circl.c pdns_dnsdb.c \
-	sort.c time.c asinfo.c
+	sort.c time.c asinfo.c deduper.c
 
 all: $(TOOL)
 
@@ -72,6 +72,7 @@ depend:
 	mkdep $(CURLINCL) $(JANSINCL) $(CDEFS) $(TOOL_SRC)
 
 # these were made by mkdep on BSD but are now staticly edited
+deduper.o: deduper.c deduper.h
 asinfo.o: asinfo.c \
   asinfo.h globals.h defs.h sort.h pdns.h netio.h
 dnsdbq.o: dnsdbq.c \

--- a/deduper.c
+++ b/deduper.c
@@ -1,0 +1,99 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "deduper.h"
+
+struct chainlink;
+typedef struct chainlink *chainlink_t;
+
+struct chainlink {
+	chainlink_t next;
+	char str[];
+};
+static inline size_t chainlink_size(size_t length) {
+	return sizeof(struct chainlink) + length + 1;
+}
+
+struct deduper {
+	size_t buckets;
+	chainlink_t chains[];
+};
+static inline size_t deduper_size(size_t buckets) {
+	return sizeof(struct deduper) + buckets * sizeof(chainlink_t);
+}
+
+static unsigned long hash_djb2(const char *);
+
+deduper_t deduper_new(size_t buckets) {
+	deduper_t ret = malloc(deduper_size(buckets));
+	if (ret == NULL)
+		abort();
+	memset(ret, 0x00, deduper_size(buckets));
+	ret->buckets = buckets;
+	return ret;
+}
+
+bool deduper_tas(deduper_t me, const char *str) {
+	size_t bucket = hash_djb2(str) % me->buckets;
+	chainlink_t chainlink;
+	for (chainlink = me->chains[bucket];
+	     chainlink != NULL;
+	     chainlink = chainlink->next)
+		if (strcmp(str, chainlink->str) == 0)
+			return true;
+	size_t len = strlen(str);
+	chainlink = malloc(chainlink_size(len));
+	if (chainlink == NULL)
+		abort();
+	memset(chainlink, 0, chainlink_size(len));
+	chainlink->next = me->chains[bucket];
+	strcpy(chainlink->str, str);
+	me->chains[bucket] = chainlink;
+	return false;
+}
+
+void
+deduper_dump(deduper_t me, FILE *out) {
+	for (size_t bucket = 0; bucket < me->buckets; bucket++)
+		if (me->chains[bucket] != NULL) {
+			fprintf(out, "[%lu]", bucket);
+			for (chainlink_t chainlink = me->chains[bucket];
+			     chainlink != NULL;
+			     chainlink = chainlink->next)
+				fprintf(out, " \"%s\"", chainlink->str);
+			fprintf(out, ".\n");
+		}
+}
+
+void
+deduper_destroy(deduper_t *me) {
+	for (size_t bucket = 0; bucket < (*me)->buckets; bucket++) {
+		chainlink_t next = (*me)->chains[bucket];
+		if (next != NULL) {
+			for (chainlink_t chainlink = next;
+			     chainlink != NULL;
+			     chainlink = next) {
+				next = chainlink->next;
+				chainlink->next = NULL;
+				free(chainlink);
+			}
+			(*me)->chains[bucket] = NULL;
+		}
+	}
+	memset(*me, 0, deduper_size((*me)->buckets));
+	free(*me);
+	*me = NULL;
+}
+
+static unsigned long
+hash_djb2(const char *str) {
+	unsigned long hash = 5381;
+	unsigned int c;
+
+	while ((c = (unsigned char) *str++) != '\0')
+		hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+
+	return hash;
+}

--- a/deduper.c
+++ b/deduper.c
@@ -28,7 +28,10 @@ struct chainlink {
 	chainlink_t next;
 	char str[];
 };
-static inline size_t chainlink_size(size_t length) {
+
+/* keep this adjacent to the related 'struct' (chainlink). */
+static inline size_t
+chainlink_size(size_t length) {
 	return sizeof(struct chainlink) + length + 1;
 }
 
@@ -36,7 +39,10 @@ struct deduper {
 	size_t buckets;
 	chainlink_t chains[];
 };
-static inline size_t deduper_size(size_t buckets) {
+
+/* keep this adjacent to the related 'struct' (deduper). */
+static inline size_t
+deduper_size(size_t buckets) {
 	return sizeof(struct deduper) + buckets * sizeof(chainlink_t);
 }
 

--- a/deduper.c
+++ b/deduper.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,7 +42,10 @@ static inline size_t deduper_size(size_t buckets) {
 
 static unsigned long hash_djb2(const char *);
 
-deduper_t deduper_new(size_t buckets) {
+/* deduper_new(buckets) -- create a deduper having a set number of buckets
+ */
+deduper_t
+deduper_new(size_t buckets) {
 	deduper_t ret = malloc(deduper_size(buckets));
 	if (ret == NULL)
 		abort();
@@ -35,7 +54,10 @@ deduper_t deduper_new(size_t buckets) {
 	return ret;
 }
 
-bool deduper_tas(deduper_t me, const char *str) {
+/* deduper_tas(str) -- test and maybe set this string in a deduper
+ */
+bool
+deduper_tas(deduper_t me, const char *str) {
 	size_t bucket = hash_djb2(str) % me->buckets;
 	chainlink_t chainlink;
 	for (chainlink = me->chains[bucket];
@@ -54,6 +76,8 @@ bool deduper_tas(deduper_t me, const char *str) {
 	return false;
 }
 
+/* deduper_dump(out) -- for debugging, render a deduper's contents to an output
+ */
 void
 deduper_dump(deduper_t me, FILE *out) {
 	for (size_t bucket = 0; bucket < me->buckets; bucket++)
@@ -67,6 +91,8 @@ deduper_dump(deduper_t me, FILE *out) {
 		}
 }
 
+/* deduper_destroy() -- release all heap storage used by a deduper
+ */
 void
 deduper_destroy(deduper_t *me) {
 	for (size_t bucket = 0; bucket < (*me)->buckets; bucket++) {
@@ -87,12 +113,14 @@ deduper_destroy(deduper_t *me) {
 	*me = NULL;
 }
 
+/* hash_djb2() -- compute daniel j. bernstein (djb2) hash #2 over a string
+ */
 static unsigned long
 hash_djb2(const char *str) {
 	unsigned long hash = 5381;
 	unsigned int c;
 
-	while ((c = (unsigned char) *str++) != '\0')
+	while ((c = (unsigned char) *str++) != 0)
 		hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
 
 	return hash;

--- a/deduper.c
+++ b/deduper.c
@@ -59,14 +59,13 @@ deduper_new(size_t buckets) {
 bool
 deduper_tas(deduper_t me, const char *str) {
 	size_t bucket = hash_djb2(str) % me->buckets;
-	chainlink_t chainlink;
-	for (chainlink = me->chains[bucket];
+	for (chainlink_t chainlink = me->chains[bucket];
 	     chainlink != NULL;
 	     chainlink = chainlink->next)
 		if (strcmp(str, chainlink->str) == 0)
 			return true;
 	size_t len = strlen(str);
-	chainlink = malloc(chainlink_size(len));
+	chainlink_t chainlink = malloc(chainlink_size(len));
 	if (chainlink == NULL)
 		abort();
 	memset(chainlink, 0, chainlink_size(len));
@@ -98,14 +97,15 @@ deduper_destroy(deduper_t *me) {
 	for (size_t bucket = 0; bucket < (*me)->buckets; bucket++) {
 		chainlink_t next = (*me)->chains[bucket];
 		if (next != NULL) {
+		       (*me)->chains[bucket] = NULL;
 			for (chainlink_t chainlink = next;
 			     chainlink != NULL;
 			     chainlink = next) {
 				next = chainlink->next;
 				chainlink->next = NULL;
+				chainlink->str[0] = '\0';
 				free(chainlink);
 			}
-			(*me)->chains[bucket] = NULL;
 		}
 	}
 	memset(*me, 0, deduper_size((*me)->buckets));

--- a/deduper.h
+++ b/deduper.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef __DEDUPER_H_INCLUDED
 #define __DEDUPER_H_INCLUDED 1
 

--- a/deduper.h
+++ b/deduper.h
@@ -1,0 +1,12 @@
+#ifndef __DEDUPER_H_INCLUDED
+#define __DEDUPER_H_INCLUDED 1
+
+struct deduper;
+typedef struct deduper *deduper_t;
+
+deduper_t deduper_new(size_t);
+bool deduper_tas(deduper_t, const char *);
+void deduper_dump(deduper_t, FILE *);
+void deduper_destroy(deduper_t *);
+
+#endif /*__DEDUPER_H_INCLUDED*/

--- a/defs.h
+++ b/defs.h
@@ -48,7 +48,7 @@
 #define DESTROY(p) { if ((p) != NULL) { free(p); (p) = NULL; } }
 #define DEBUG(ge, ...) { if (debug_level >= (ge)) debug(__VA_ARGS__); }
 
-typedef enum { pres_text, pres_json, pres_csv, pres_rdata } present_e;
+typedef enum { pres_text, pres_json, pres_csv, pres_minimal } present_e;
 typedef enum { batch_none, batch_terse, batch_verbose } batch_e;
 
 #define TRANS_REVERSE	0x01
@@ -76,5 +76,9 @@ debug(bool want_header, const char *fmtstr, ...) {
 	vfprintf(stderr, fmtstr, ap);
 	va_end(ap);
 }
+
+/* a query mode. not all pdns systems support all of these. */
+typedef enum { no_mode = 0, rrset_mode, name_mode, ip_mode,
+	       raw_rrset_mode, raw_name_mode } mode_e;
 
 #endif /*DEFS_H_INCLUDED*/

--- a/defs.h
+++ b/defs.h
@@ -48,7 +48,8 @@
 #define DESTROY(p) { if ((p) != NULL) { free(p); (p) = NULL; } }
 #define DEBUG(ge, ...) { if (debug_level >= (ge)) debug(__VA_ARGS__); }
 
-typedef enum { pres_text, pres_json, pres_csv, pres_minimal } present_e;
+typedef enum { pres_none, pres_text, pres_json, pres_csv, pres_minimal }
+	present_e;
 typedef enum { batch_none, batch_terse, batch_verbose } batch_e;
 
 #define TRANS_REVERSE	0x01

--- a/defs.h
+++ b/defs.h
@@ -48,7 +48,7 @@
 #define DESTROY(p) { if ((p) != NULL) { free(p); (p) = NULL; } }
 #define DEBUG(ge, ...) { if (debug_level >= (ge)) debug(__VA_ARGS__); }
 
-typedef enum { pres_text, pres_json, pres_csv } present_e;
+typedef enum { pres_text, pres_json, pres_csv, pres_rdata } present_e;
 typedef enum { batch_none, batch_terse, batch_verbose } batch_e;
 
 #define TRANS_REVERSE	0x01

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -708,7 +708,7 @@ static void
 help(void) {
 	verb_ct v;
 
-	printf("usage: %s [-acdfGghIjmqSsUv468] [-p dns|json|csv]\n",
+	printf("usage: %s [-acdfGghIjmqSsUv468] [-p dns|json|csv|minimal]\n",
 	       program_name);
 	puts("\t[-u SYSTEM] [-V VERB] [-0 FUNCTION=INPUT]\n"
 	     "\t[-k (first|last|duration|count|name|data)[,...]]\n"

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -472,6 +472,9 @@ main(int argc, char *argv[]) {
 #endif
 	}
 
+	if (presentation == pres_minimal)
+		minimal_deduper = deduper_new(10000);
+
 	/* recondition various options for HTML use. */
 	CURL *easy = curl_easy_init();
 	escape(easy, &qd.thing);
@@ -633,6 +636,10 @@ main(int argc, char *argv[]) {
  */
 __attribute__((noreturn)) void
 my_exit(int code) {
+	/* deduper state if any can be trashed. */
+	if (presentation == pres_minimal)
+		deduper_destroy(&minimal_deduper);
+
 	/* writers and readers which are still known, must be freed. */
 	unmake_writers();
 

--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -95,12 +95,14 @@ const struct verb verbs[] = {
 	{ "lookup", "/lookup", lookup_ok,
 	  present_text_lookup,
 	  present_json_lookup,
-	  present_csv_lookup },
+	  present_csv_lookup,
+	  present_rdata_lookup },
 	{ "summarize", "/summarize", summarize_ok,
 	  present_text_summarize,
 	  present_json_summarize,
-	  present_csv_summarize },
-	{ NULL, NULL, NULL, NULL, NULL, NULL }
+	  present_csv_summarize,
+	  NULL },
+	{ NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
 
 /* Private. */
@@ -332,6 +334,8 @@ main(int argc, char *argv[]) {
 			else if (strcasecmp(optarg, "text") == 0 ||
 				 strcasecmp(optarg, "dns") == 0)
 				presentation = pres_text;
+			else if (strcasecmp(optarg, "rdata") == 0)
+				presentation = pres_rdata;
 			else
 				usage("-p must specify json, text, or csv");
 			break;
@@ -499,6 +503,9 @@ main(int argc, char *argv[]) {
 		break;
 	case pres_csv:
 		presenter = pverb->csv;
+		break;
+	case pres_rdata:
+		presenter = pverb->rdata;
 		break;
 	default:
 		abort();

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -334,7 +334,8 @@ See the
 environment variable for controlling how
 timestamps are formatted for this option.
 .It Cm minimal
-outputs only the owner name or rdata, one per line, for use by shell scripts.
+outputs only the owner name or rdata, one per line and deduplicated,
+for use by shell scripts.
 .El
 .It Fl q
 makes the program reticent about warnings.

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -333,8 +333,8 @@ See the
 .Ic DNSDBQ_TIME_FORMAT
 environment variable for controlling how
 timestamps are formatted for this option.
-.It Cm rdata
-outputs only the rdata values, one per line, for use by shell scripts.
+.It Cm minimal
+outputs only the owner name or rdata, one per line, for use by shell scripts.
 .El
 .It Fl q
 makes the program reticent about warnings.

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -334,7 +334,7 @@ See the
 environment variable for controlling how
 timestamps are formatted for this option.
 .It Cm minimal
-outputs only the owner name or rdata, one per line and deduplicated,
+outputs only the owner name or rdata, one per line and deduplicated;
 for use by shell scripts.
 .El
 .It Fl q

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -326,14 +326,15 @@ is a synonym, for compatibility with older programmatic callers.
 .It Cm json
 for newline delimited JSON output.
 .It Cm csv
-for comma separated value output. This format is information losing,
-since
+for comma separated value output. This format is information losing, since
 it cannot express multiple resource records that are in a single RRset.
 Instead, each resource record is expressed in a separate line of output.
 See the
 .Ic DNSDBQ_TIME_FORMAT
 environment variable for controlling how
 timestamps are formatted for this option.
+.It Cm rdata
+outputs only the rdata values, one per line, for use by shell scripts.
 .El
 .It Fl q
 makes the program reticent about warnings.

--- a/globals.h
+++ b/globals.h
@@ -60,12 +60,19 @@ EXTERN	int transforms			INIT(0);
 EXTERN	long max_count			INIT(0L);
 EXTERN	sort_e sorting			INIT(no_sort);
 EXTERN	batch_e batching		INIT(batch_none);
-EXTERN	present_e presentation		INIT(pres_text);
+EXTERN	present_e presentation		INIT(pres_none);
+EXTERN	char *presentation_name		INIT(NULL);
 EXTERN	present_t presenter		INIT(NULL);
 EXTERN	struct timeval startup_time	INIT({});
 EXTERN	int exit_code			INIT(0);
 EXTERN	long curl_ipresolve		INIT(CURL_IPRESOLVE_WHATEVER);
 EXTERN	deduper_t minimal_deduper	INIT(NULL);
+
+/* deduplication table size. trades memory efficiency (an array of this many
+ * pointers will be allocated under '-p minimal' conditions) against run time
+ * efficiency (the string's hash will be modulo this size).
+ */
+EXTERN	const size_t minimal_modulus	INIT(10000);
 
 #undef INIT
 #undef EXTERN

--- a/globals.h
+++ b/globals.h
@@ -34,7 +34,7 @@ extern const struct verb verbs[];
 #endif
 
 EXTERN	const char id_swclient[]	INIT("dnsdbq");
-EXTERN	const char id_version[]		INIT("2.5.6");
+EXTERN	const char id_version[]		INIT("2.5.7");
 EXTERN	const char *program_name	INIT(NULL);
 EXTERN	const char path_sort[]		INIT("/usr/bin/sort");
 EXTERN	const char json_header[]	INIT("Accept: application/json");

--- a/globals.h
+++ b/globals.h
@@ -18,6 +18,7 @@
 #define GLOBALS_H_INCLUDED 1
 
 #include "defs.h"
+#include "deduper.h"
 #include "sort.h"
 
 #ifdef MAIN_PROGRAM
@@ -64,6 +65,7 @@ EXTERN	present_t presenter		INIT(NULL);
 EXTERN	struct timeval startup_time	INIT({});
 EXTERN	int exit_code			INIT(0);
 EXTERN	long curl_ipresolve		INIT(CURL_IPRESOLVE_WHATEVER);
+EXTERN	deduper_t minimal_deduper	INIT(NULL);
 
 #undef INIT
 #undef EXTERN

--- a/netio.c
+++ b/netio.c
@@ -585,6 +585,20 @@ writer_fini(writer_t writer) {
 				continue;
 			}
 			linep += strspn(linep, " ");
+			mode_e mode = (mode_e) (int) strtol(linep, NULL, 10);
+			if (mode == no_mode) {
+				fprintf(stderr,
+					"%s: invalid mode from sort in '%s'\n",
+					program_name, line);
+				continue;
+			}
+			if ((linep = strchr(linep, ' ')) == NULL) {
+				fprintf(stderr,
+					"%s: warning: no seventh SP in '%s'\n",
+					program_name, line);
+				continue;
+			}
+			linep += strspn(linep, " ");
 			DEBUG(2, true, "sort2: '%*.*s'\n",
 				 (int)(nl - linep),
 				 (int)(nl - linep),
@@ -597,7 +611,7 @@ writer_fini(writer_t writer) {
 					program_name, msg);
 				continue;
 			}
-			(*presenter)(&tup, linep, len, writer);
+			(*presenter)(&tup, mode, writer);
 			tuple_unmake(&tup);
 			count++;
 		}

--- a/netio.c
+++ b/netio.c
@@ -401,9 +401,9 @@ query_done(query_t query) {
 		const char *msg = or_else(query->saf_msg, "");
 
 		if (query->saf_cond == sc_limited)
-			fprintf(stderr, "Query limited: %s\n", msg);
+			fprintf(stderr, "Database limit: %s\n", msg);
 		else if (query->saf_cond == sc_failed)
-			fprintf(stderr, "Query failed: %s\n", msg);
+			fprintf(stderr, "Database failure: %s\n", msg);
 		else if (query->saf_cond == sc_missing)
 			fprintf(stderr, "Query response missing: %s\n", msg);
 		else if (query->status != NULL)

--- a/netio.c
+++ b/netio.c
@@ -403,7 +403,7 @@ query_done(query_t query) {
 		if (query->saf_cond == sc_limited)
 			fprintf(stderr, "Database limit: %s\n", msg);
 		else if (query->saf_cond == sc_failed)
-			fprintf(stderr, "Database failure: %s\n", msg);
+			fprintf(stderr, "Database result: %s\n", msg);
 		else if (query->saf_cond == sc_missing)
 			fprintf(stderr, "Query response missing: %s\n", msg);
 		else if (query->status != NULL)

--- a/netio.h
+++ b/netio.h
@@ -49,7 +49,7 @@ struct qparam {
 typedef struct qparam *qparam_t;
 typedef const struct qparam *qparam_ct;
 
-/* one API fetch; several may be needed for some kinds of time fencing. */
+/* one API fetch; several may be needed for complex kinds of query. */
 struct fetch {
 	struct fetch	*next;
 	struct query	*query;
@@ -70,6 +70,7 @@ struct query {
 	struct writer	*writer;
 	struct qparam	params;
 	char		*command;
+	mode_e		mode;
 	/* invariant: (status == NULL) == (writer == NULL) */
 	char		*status;
 	char		*message;

--- a/pdns.c
+++ b/pdns.c
@@ -495,6 +495,32 @@ present_csv_line(pdns_tuple_ct tup, const char *rdata) {
 	putchar('\n');
 }
 
+/* present_rdata_lookup -- render one DNSDB tuple as an rdata-only "line" (RDATA)
+ */
+void
+present_rdata_lookup(pdns_tuple_ct tup,
+		     const char *jsonbuf __attribute__ ((unused)),
+		     size_t jsonlen __attribute__ ((unused)),
+		     writer_t writer __attribute__ ((unused)))
+{
+	if (json_is_array(tup->obj.rdata)) {
+		size_t index;
+		json_t *rr;
+
+		json_array_foreach(tup->obj.rdata, index, rr) {
+			const char *rdata = NULL;
+
+			if (json_is_string(rr))
+				rdata = json_string_value(rr);
+			else
+				rdata = "[bad value]";
+			puts(rdata);
+		}
+	} else {
+		puts(tup->rdata);
+	}
+}
+
 /* present_csv_summ -- render a summarize result as CSV.
  */
 void

--- a/pdns.c
+++ b/pdns.c
@@ -33,6 +33,7 @@
 
 static void present_text_line(const char *, const char *, const char *);
 static void present_csv_line(pdns_tuple_ct, const char *);
+static void present_minimal_thing(const char *thing);
 static json_t *annotate_json(pdns_tuple_ct, bool);
 static json_t *annotate_one(json_t *, const char *, const char *, json_t *);
 #ifndef CRIPPLED_LIBC
@@ -516,7 +517,7 @@ present_minimal_lookup(pdns_tuple_ct tup,
 
 	/* for RHS queries, output the LHS once, and exit. */
 	if (!left) {
-		puts(tup->rrname);
+		present_minimal_thing(tup->rrname);
 		return;
 	}
 
@@ -532,11 +533,17 @@ present_minimal_lookup(pdns_tuple_ct tup,
 				rdata = json_string_value(rr);
 			else
 				rdata = "[bad value]";
-			puts(rdata);
+			present_minimal_thing(rdata);
 		}
 	} else {
-		puts(tup->rdata);
+		present_minimal_thing(tup->rdata);
 	}
+}
+
+static void
+present_minimal_thing(const char *thing) {
+	if (!deduper_tas(minimal_deduper, thing))
+		puts(thing);
 }
 
 /* present_csv_summ -- render a summarize result as CSV.

--- a/pdns.c
+++ b/pdns.c
@@ -44,8 +44,7 @@ static struct counted *countoff_r(const char *, int);
  */
 void
 present_text_lookup(pdns_tuple_ct tup,
-		    const char *jsonbuf __attribute__ ((unused)),
-		    size_t jsonlen __attribute__ ((unused)),
+		    mode_e mode __attribute__ ((unused)),
 		    writer_t writer __attribute__ ((unused)))
 {
 	bool pflag, ppflag;
@@ -167,8 +166,7 @@ present_text_line(const char *rrname, const char *rrtype, const char *rdata) {
  */
 void
 present_text_summarize(pdns_tuple_ct tup,
-		       const char *jsonbuf __attribute__ ((unused)),
-		       size_t jsonlen __attribute__ ((unused)),
+		       mode_e mode __attribute__ ((unused)),
 		       writer_t writer __attribute__ ((unused)))
 {
 	const char *prefix;
@@ -231,8 +229,7 @@ pprint_json(const char *buf, size_t len, FILE *outf) {
  */
 void
 present_json_lookup(pdns_tuple_ct tup,
-		    const char *jsonbuf __attribute__ ((unused)),
-		    size_t jsonlen __attribute__ ((unused)),
+		    mode_e mode __attribute__ ((unused)),
 		    writer_t writer __attribute__ ((unused)))
 {
 	present_json(tup, true);
@@ -242,8 +239,7 @@ present_json_lookup(pdns_tuple_ct tup,
  */
 void
 present_json_summarize(pdns_tuple_ct tup,
-		       const char *jsonbuf __attribute__ ((unused)),
-		       size_t jsonlen __attribute__ ((unused)),
+		       mode_e mode __attribute__ ((unused)),
 		       writer_t writer __attribute__ ((unused)))
 {
 	present_json(tup, false);
@@ -402,8 +398,7 @@ annotate_asinfo(const char *rrtype, const char *rdata) {
  */
 void
 present_csv_lookup(pdns_tuple_ct tup,
-		   const char *jsonbuf __attribute__ ((unused)),
-		   size_t jsonlen __attribute__ ((unused)),
+		   mode_e mode __attribute__ ((unused)),
 		   writer_t writer)
 {
 	if (!writer->csv_headerp) {
@@ -495,14 +490,37 @@ present_csv_line(pdns_tuple_ct tup, const char *rdata) {
 	putchar('\n');
 }
 
-/* present_rdata_lookup -- render one DNSDB tuple as an rdata-only "line" (RDATA)
+/* present_rdata_lookup -- render one DNSDB tuple as a "line" (MINIMAL)
  */
 void
-present_rdata_lookup(pdns_tuple_ct tup,
-		     const char *jsonbuf __attribute__ ((unused)),
-		     size_t jsonlen __attribute__ ((unused)),
-		     writer_t writer __attribute__ ((unused)))
+present_minimal_lookup(pdns_tuple_ct tup,
+		       mode_e mode __attribute__ ((unused)),
+		       writer_t writer __attribute__ ((unused)))
 {
+	/* did this tuple come from a left hand or right hand query? */
+	bool left = true;
+	switch (mode) {
+	case no_mode:
+		abort();
+	case rrset_mode:
+		/* FALLTHROUGH */
+	case raw_rrset_mode:
+		break;
+	case name_mode:
+		/* FALLTHROUGH */
+	case ip_mode:
+		/* FALLTHROUGH */
+	case raw_name_mode:
+		left = false;
+	}
+
+	/* for RHS queries, output the LHS once, and exit. */
+	if (!left) {
+		puts(tup->rrname);
+		return;
+	}
+
+	/* for LHS queries, output each RHS found. */
 	if (json_is_array(tup->obj.rdata)) {
 		size_t index;
 		json_t *rr;
@@ -525,8 +543,7 @@ present_rdata_lookup(pdns_tuple_ct tup,
  */
 void
 present_csv_summarize(pdns_tuple_ct tup,
-		      const char *jsonbuf __attribute__ ((unused)),
-		      size_t jsonlen __attribute__ ((unused)),
+		      mode_e mode __attribute__ ((unused)),
 		      writer_t writer __attribute__ ((unused)))
 {
 	printf("time_first,time_last,zone_first,zone_last,"
@@ -849,7 +866,7 @@ reverse(const char *src) {
 
 /* data_blob -- process one deblocked json blob as a counted string.
  *
- * presents each blob and then frees it.
+ * presents, or outputs to POSIX sort(1), each blob and then frees it.
  * returns number of tuples processed (for now, 1 or 0).
  */
 int
@@ -937,26 +954,28 @@ data_blob(query_t query, const char *buf, size_t len) {
 
 		DEBUG(3, true, "dyn_rrname = '%s'\n", dyn_rrname);
 		DEBUG(3, true, "dyn_rdata = '%s'\n", dyn_rdata);
-		fprintf(writer->sort_stdin, "%lu %lu %lu %lu %s %s %*.*s\n",
+		fprintf(writer->sort_stdin, "%lu %lu %lu %lu %s %s %d %*.*s\n",
 			(unsigned long)first,
 			(unsigned long)last,
 			(unsigned long)(last - first),
 			(unsigned long)tup.count,
 			or_else(dyn_rrname, "n/a"),
 			or_else(dyn_rdata, "n/a"),
+			(int)query->mode,
 			(int)len, (int)len, buf);
-		DEBUG(2, true, "sort0: '%lu %lu %lu %lu %s %s %*.*s'\n",
+		DEBUG(2, true, "sort0: '%lu %lu %lu %lu %s %s %d %*.*s'\n",
 			 (unsigned long)first,
 			 (unsigned long)last,
 			 (unsigned long)(last - first),
 			 (unsigned long)tup.count,
 			 or_else(dyn_rrname, "n/a"),
 			 or_else(dyn_rdata, "n/a"),
+			 (int)query->mode,
 			 (int)len, (int)len, buf);
 		DESTROY(dyn_rrname);
 		DESTROY(dyn_rdata);
 	} else {
-		(*presenter)(&tup, buf, len, writer);
+		(*presenter)(&tup, query->mode, writer);
 	}
 
 	ret = 1;

--- a/pdns.h
+++ b/pdns.h
@@ -133,7 +133,7 @@ struct verb {
 	const char *	(*ok)(void);
 
 	/* formatter function for each presentation format */
-	present_t	text, json, csv;
+	present_t	text, json, csv, rdata;
 };
 typedef const struct verb *verb_ct;
 
@@ -167,6 +167,7 @@ void present_json_summarize(pdns_tuple_ct, const char *, size_t, writer_t);
 void present_json(pdns_tuple_ct, bool);
 void present_text_lookup(pdns_tuple_ct, const char *, size_t, writer_t);
 void present_csv_lookup(pdns_tuple_ct, const char *, size_t, writer_t);
+void present_rdata_lookup(pdns_tuple_ct, const char *, size_t, writer_t);
 void present_text_summarize(pdns_tuple_ct, const char *, size_t, writer_t);
 void present_csv_summarize(pdns_tuple_ct, const char *, size_t, writer_t);
 const char *tuple_make(pdns_tuple_t, const char *, size_t);

--- a/pdns.h
+++ b/pdns.h
@@ -20,12 +20,12 @@
 #include <jansson.h>
 #include "netio.h"
 
-/* main is the primary jansson library object from a json_loadb().
+/* ".main" is the primary jansson library object from a json_loadb().
  * all the other fields in this structure will point inside main, as
  * borrowed references, so const.  main must be deallocated
  * by json_decref() which then invalidates all the other fields.
  *
- * cof_obj points to the object that contains time_first...num_results.
+ * ".cof_obj" points to the object that contains time_first...num_results.
  * If not using SAF encapulation, then cof_obj points to main.
  * If using SAF encapulation, then saf_cond, saf_msg, and saf_obj are
  * parsed from main and cof_obj is repointed to saf_obj.
@@ -117,7 +117,7 @@ struct pdns_system {
 };
 typedef const struct pdns_system *pdns_system_ct;
 
-typedef void (*present_t)(pdns_tuple_ct, const char *, size_t, writer_t);
+typedef void (*present_t)(pdns_tuple_ct, mode_e, writer_t);
 
 /* a verb is a specific type of request.  See struct pdns_system
  * verb_ok() for that function that verifies if the verb and the options
@@ -133,13 +133,9 @@ struct verb {
 	const char *	(*ok)(void);
 
 	/* formatter function for each presentation format */
-	present_t	text, json, csv, rdata;
+	present_t	text, json, csv, minimal;
 };
 typedef const struct verb *verb_ct;
-
-/* a query mode. not all pdns systems support all of these. */
-typedef enum { no_mode = 0, rrset_mode, name_mode, ip_mode,
-	       raw_rrset_mode, raw_name_mode } mode_e;
 
 /* query parameters descriptor. */
 struct qdesc {
@@ -162,14 +158,14 @@ struct counted {
 	(sizeof(struct counted) + (unsigned int) nlabel * sizeof(size_t))
 
 bool pprint_json(const char *, size_t, FILE *);
-void present_json_lookup(pdns_tuple_ct, const char *, size_t, writer_t);
-void present_json_summarize(pdns_tuple_ct, const char *, size_t, writer_t);
+void present_json_lookup(pdns_tuple_ct, mode_e, writer_t);
+void present_json_summarize(pdns_tuple_ct, mode_e, writer_t);
 void present_json(pdns_tuple_ct, bool);
-void present_text_lookup(pdns_tuple_ct, const char *, size_t, writer_t);
-void present_csv_lookup(pdns_tuple_ct, const char *, size_t, writer_t);
-void present_rdata_lookup(pdns_tuple_ct, const char *, size_t, writer_t);
-void present_text_summarize(pdns_tuple_ct, const char *, size_t, writer_t);
-void present_csv_summarize(pdns_tuple_ct, const char *, size_t, writer_t);
+void present_text_lookup(pdns_tuple_ct, mode_e, writer_t);
+void present_csv_lookup(pdns_tuple_ct, mode_e, writer_t);
+void present_minimal_lookup(pdns_tuple_ct, mode_e, writer_t);
+void present_text_summarize(pdns_tuple_ct, mode_e, writer_t);
+void present_csv_summarize(pdns_tuple_ct, mode_e, writer_t);
 const char *tuple_make(pdns_tuple_t, const char *, size_t);
 void tuple_unmake(pdns_tuple_t);
 struct counted *countoff(const char *);

--- a/pdns_dnsdb.c
+++ b/pdns_dnsdb.c
@@ -347,6 +347,8 @@ dnsdb_infoback(writer_t writer) {
 		break;
 	case pres_csv:
 		/* FALLTHROUGH */
+	case pres_none:
+		/* FALLTHROUGH */
 	case pres_minimal:
 		abort();
 	}

--- a/pdns_dnsdb.c
+++ b/pdns_dnsdb.c
@@ -347,7 +347,7 @@ dnsdb_infoback(writer_t writer) {
 		break;
 	case pres_csv:
 		/* FALLTHROUGH */
-	case pres_rdata:
+	case pres_minimal:
 		abort();
 	}
 }

--- a/pdns_dnsdb.c
+++ b/pdns_dnsdb.c
@@ -346,6 +346,8 @@ dnsdb_infoback(writer_t writer) {
 		(void) pprint_json(writer->ps_buf, writer->ps_len, stdout);
 		break;
 	case pres_csv:
+		/* FALLTHROUGH */
+	case pres_rdata:
 		abort();
 	}
 }


### PR DESCRIPTION
add new -p option, 'minimal'. this emits only unique keys or values, one per line, for use by shell scripts. also killed some lint.