### PR TITLE
use 'zu' format string in deduper_dump()

### DIFF
--- a/deduper.c
+++ b/deduper.c
@@ -87,7 +87,7 @@ void
 deduper_dump(deduper_t me, FILE *out) {
 	for (size_t bucket = 0; bucket < me->buckets; bucket++)
 		if (me->chains[bucket] != NULL) {
-			fprintf(out, "[%lu]", bucket);
+			fprintf(out, "[%zu]", bucket);
 			for (chainlink_t chainlink = me->chains[bucket];
 			     chainlink != NULL;
 			     chainlink = chainlink->next)


### PR DESCRIPTION
The use of `lu` to format a `size_t` leads to build failures (via `-Werror`) on many architectures. See example from a Debian build for ARM below.

```
cc -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wno-unused-result  -g -O3 -W -Wall -Wextra -Wcast-qual -Wpointer-arith -Wwrite-strings -Wmissing-prototypes  -Wbad-function-cast -Wnested-externs -Wunused -Wshadow -Wmissing-noreturn -Wswitch-enum -Wconversion -Werror -DWANT_PDNS_DNSDB=1 -DWANT_PDNS_CIRCL=1 -Wdate-time -D_FORTIFY_SOURCE=2 `curl-config --cflags`  -I/usr/local/include -c deduper.c
deduper.c: In function ‘deduper_dump’:
deduper.c:90:42: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘size_t’ {aka ‘unsigned int’} [-Werror=format=]
   90 |                         fprintf(out, "[%lu]", bucket);
      |                                        ~~^    ~~~~~~
      |                                          |    |
      |                                          |    size_t {aka unsigned int}
      |                                          long unsigned int
      |                                        %u
cc1: all warnings being treated as errors
make[1]: *** [Makefile:66: deduper.o] Error 1
```