### PR TITLE
ctype.h functions require int arguments.  cygwin gcc enforces this.

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -1448,8 +1448,8 @@ rrtype_correctness(const char *input) {
 	     rrtype = strtok_r(NULL, ",", &saveptr))
 	{
 		for (char *p = rrtype; *p != '\0'; p++)
-			if (isupper(*p))
-				*p = (char) tolower(*p);
+			if (isupper((int)*p))
+				*p = (char) tolower((int)*p);
 		if (nrrtypeset == MAX_FETCHES) {
 			ret = "too many rrtypes specified";
 			goto done;

--- a/globals.h
+++ b/globals.h
@@ -34,7 +34,7 @@ extern const struct verb verbs[];
 #endif
 
 EXTERN	const char id_swclient[]	INIT("dnsdbq");
-EXTERN	const char id_version[]		INIT("2.6.0");
+EXTERN	const char id_version[]		INIT("2.6.1");
 EXTERN	const char *program_name	INIT(NULL);
 EXTERN	const char path_sort[]		INIT("/usr/bin/sort");
 EXTERN	const char json_header[]	INIT("Accept: application/json");


### PR DESCRIPTION
Update version to 2.6.1

(Reported by Boris)