### PR TITLE
Commit c629aafe broke applying query parameters to queries.  

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -1366,6 +1366,7 @@ query_launcher(qdesc_ct qdp, qparam_ct qpp, writer_t writer) {
 
 	/* ready player one. */
 	CREATE(query, sizeof(struct query));
+	query->params = *qpp;
 
 	/* define the fence. */
 	if (qpp->after != 0) {
@@ -1427,7 +1428,6 @@ query_launcher(qdesc_ct qdp, qparam_ct qpp, writer_t writer) {
 	/* finish query initialization, link it up, and return it. */
 	query->writer = writer;
 	writer = NULL;
-	query->params = *qpp;
 	query->next = query->writer->queries;
 	query->writer->queries = query;
 	query->descrip = makepath(qdp);

--- a/globals.h
+++ b/globals.h
@@ -34,7 +34,7 @@ extern const struct verb verbs[];
 #endif
 
 EXTERN	const char id_swclient[]	INIT("dnsdbq");
-EXTERN	const char id_version[]		INIT("2.6.1");
+EXTERN	const char id_version[]		INIT("2.6.2");
 EXTERN	const char *program_name	INIT(NULL);
 EXTERN	const char path_sort[]		INIT("/usr/bin/sort");
 EXTERN	const char json_header[]	INIT("Accept: application/json");


### PR DESCRIPTION
Version set to 2.6.2 because 2.6.0 and 2.6.1 are broken.

Running like "dnsdbq -l 3" was sending a query with "limit=0"
`https://api.dnsdb.info/dnsdb/v2/lookup/rrset/name/fsi.io?swclient=dnsdbq&version=2.6.0&limit=0`
The query limit value was being applied as an output limit, which is why only 3 results were printed from that query.

When query_launcher()` was refactored in commit c629aafe, code including `query->params = *qpp;`
was moved to the end, which is after `launch_fetch(query, path, &fence);` is run.  I moved just that assignment up where it was prior to commit c629aafe.  
Please review that none of other assignments to `query->` that are the end of the function need to be moved back up also.
