### PR TITLE
tokstr regions

### DIFF
--- a/tokstr.c
+++ b/tokstr.c
@@ -7,7 +7,6 @@
 #define _GNU_SOURCE
 
 #include <assert.h>
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -112,10 +111,8 @@ tokstr_next_copy(struct tokstr *ts, const char *delims,
 	struct tokstr_reg reg = tokstr_next_region(ts, delims);
 	if (reg.base == NULL)
 		return 0;
-	if (reg.size >= size) {
-		errno = EMSGSIZE;
+	if (reg.size >= size)
 		return -1;
-	}
 	memcpy(buffer, reg.base, reg.size);
 	buffer[reg.size] = '\0';
 	return (ssize_t) reg.size;

--- a/tokstr.c
+++ b/tokstr.c
@@ -1,10 +1,13 @@
 // tokstr -- textual token iterator with some input independence
+// 2022-01-29 [revised during code review, add regions]
 // 2022-01-25 [initially released inside dnsdbq]
 
 /* externals. */
 
 #define _GNU_SOURCE
 
+#include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -18,10 +21,9 @@ struct tokstr_class {
 	enum tokstr_type	type;
 };
 
-struct tokstr_buffer {
+struct tokstr_region {
 	struct tokstr_class	class;
-	const char		*source;
-	size_t			size;
+	struct tokstr_reg	source;
 };
 
 struct tokstr_string {
@@ -32,29 +34,28 @@ struct tokstr_string {
 struct tokstr {
 	union {
 		struct tokstr_class	class;
-		struct tokstr_buffer	buffer;
+		struct tokstr_region	region;
 		struct tokstr_string	string;
 	} data;
 };
 
 /* forward. */
 
-static char *next_buffer(struct tokstr_buffer *, const char *);
-static char *next_string(struct tokstr_string *, const char *);
+static struct tokstr_reg next_region(struct tokstr_region *, const char *);
+static struct tokstr_reg next_string(struct tokstr_string *, const char *);
 
 /* public. */
 
 // tokstr_buffer -- create an iterator for a counted string
 tokstr_t
-tokstr_buffer(const char *source, size_t size) {
-	tokstr_t ts = malloc(sizeof(struct tokstr_buffer));
+tokstr_region(struct tokstr_reg source) {
+	tokstr_t ts = malloc(sizeof(struct tokstr_region));
 	if (ts != NULL) {
-		ts->data.buffer = (struct tokstr_buffer) {
+		ts->data.region = (struct tokstr_region) {
 			.class = (struct tokstr_class) {
 				.type = ts_buffer,
 				},
 			.source = source,
-			.size = size,
 		};
 	}
 	return ts;
@@ -78,18 +79,43 @@ tokstr_string(const char *source) {
 // tokstr_next -- return next token from an iterator (caller must free() this)
 char *
 tokstr_next(tokstr_t ts, const char *delims) {
-	char *ret = NULL;
+	struct tokstr_reg reg = tokstr_next_region(ts, delims);
+	if (reg.base == NULL)
+		return NULL;
+	return strndup(reg.base, reg.size);
+}
+
+// tokstr_next_copy -- copy next token from an iterator; return size, 0, or -1
+ssize_t
+tokstr_next_copy(tokstr_t ts, const char *delims, char *buffer, size_t size) {
+	struct tokstr_reg reg = tokstr_next_region(ts, delims);
+	if (reg.base == NULL)
+		return 0;
+	if (reg.size >= size) {
+		errno = EMSGSIZE;
+		return -1;
+	}
+	memcpy(buffer, reg.base, reg.size);
+	buffer[reg.size] = '\0';
+	return (ssize_t) reg.size;
+}
+
+// tokstr_next_region -- return region of next token
+struct tokstr_reg
+tokstr_next_region(tokstr_t ts, const char *delims) {
+	struct tokstr_reg reg = {};
 	switch (ts->data.class.type) {
 	case ts_buffer:
-		ret = next_buffer(&ts->data.buffer, delims);
+		reg = next_region(&ts->data.region, delims);
 		break;
 	case ts_string:
-		ret = next_string(&ts->data.string, delims);
+		reg = next_string(&ts->data.string, delims);
 		break;
 	default:
 		abort();
 	}
-	return ret;
+	assert((reg.base == NULL) == (reg.size == 0));
+	return reg;
 }
 
 // tokstr_last -- destroy an iterator and release all of its internal resources
@@ -102,37 +128,36 @@ tokstr_last(tokstr_t *pts) {
 /* private functions. */
 
 // next_buffer -- implement tokstr_next for counted string iterators
-static char *
-next_buffer(struct tokstr_buffer *buf, const char *delims) {
-	char *ret = NULL;
-	if (buf->size != 0) {
-		while (buf->size != 0 && strchr(delims, *buf->source) != 0)
-			buf->size--, buf->source++;
-		const char *prev = buf->source;
-		while (buf->size != 0 && strchr(delims, *buf->source) == 0)
-			buf->size--, buf->source++;
-		size_t size = (size_t) (buf->source - prev);
+static struct tokstr_reg
+next_region(struct tokstr_region *reg, const char *delims) {
+	if (reg->source.size != 0) {
+		while (reg->source.size != 0 &&
+		       strchr(delims, *reg->source.base) != 0)
+			reg->source.size--, reg->source.base++;
+		const char *prev = reg->source.base;
+		while (reg->source.size != 0 &&
+		       strchr(delims, *reg->source.base) == 0)
+			reg->source.size--, reg->source.base++;
+		size_t size = (size_t) (reg->source.base - prev);
 		if (size != 0)
-			ret = strndup(prev, size);
+			return (struct tokstr_reg) {prev, size};
 	}
-	return ret;
+	return (struct tokstr_reg) {};
 }
 
 // next_string -- implement tokstr_next for nul-terminated string iterators
-static char *
+static struct tokstr_reg
 next_string(struct tokstr_string *str, const char *delims) {
-	char *ret = NULL;
 	int ch = *str->source;
 	if (ch != '\0') {
 		while (ch != '\0' && strchr(delims, ch) != NULL)
 			ch = *++str->source;
-		const char *next = str->source;
+		const char *prev = str->source;
 		while (ch != '\0' && strchr(delims, ch) == NULL)
-			ch = *++next;
-		size_t size = (size_t) (next - str->source);
+			ch = *++str->source;
+		size_t size = (size_t) (str->source - prev);
 		if (size != 0)
-			ret = strndup(str->source, size);
-		str->source = next;
+			return (struct tokstr_reg) {prev, size};
 	}
-	return ret;
+	return (struct tokstr_reg) {};
 }

--- a/tokstr.c
+++ b/tokstr.c
@@ -76,7 +76,7 @@ tokstr_string(const char *source) {
 	return (struct tokstr *) ts;
 }
 
-// tokstr_next -- return next token from an iterator (strndup)
+// tokstr_next -- return next token from an iterator (which must be free()'d)
 char *
 tokstr_next(struct tokstr *ts_pub, const char *delims) {
 	struct tokstr_reg reg = tokstr_next_region(ts_pub, delims);

--- a/tokstr.h
+++ b/tokstr.h
@@ -7,21 +7,21 @@
 
 /* example using heap-allocated strings:
 
-	tokstr_t ts = tokstr_string("this:is+-test");
+	struct tokstr *ts = tokstr_string("this:is+-test");
 	for (char *t; (t = tokstr_next(ts, "-:+")) != NULL; free(t))
 		printf("\t\"%s\"\n", t);
 	tokstr_last(&ts);
 
  * will output "this", "is", and "test". so will this:
 
-	tokstr_t ts = tokstr_string("this:is+-test");
+	struct tokstr *ts = tokstr_string("this:is+-test");
 	for (char t[100]; tokstr_next_copy(ts, "-:+", t, sizeof t) > 0;)
 		printf("\t\"%s\"\n", t);
 	tokstr_last(&ts);
 
  * as will this:
 
-	tokstr_t ts = tokstr_string("this:is+-test");
+	struct tokstr *ts = tokstr_string("this:is+-test");
 	for (;;) {
 		struct tokstr_reg t = tokstr_next_region(ts, "-:+");
 		if (t.base == NULL)

--- a/tokstr.h
+++ b/tokstr.h
@@ -59,6 +59,7 @@ ssize_t tokstr_next_copy(struct tokstr *, const char *, char *, size_t);
 
 // tokstr_next_region -- return next token from iterator (zero-copy)
 // (.base == NULL means no more tokens are available.)
+// NOTE WELL: if program state becomes undefined here, can assert() or abort()
 struct tokstr_reg tokstr_next_region(struct tokstr *, const char *);
 
 // tokstr_last -- destroy an iterator and release all of its internal resources

--- a/tokstr.h
+++ b/tokstr.h
@@ -50,12 +50,15 @@ struct tokstr *tokstr_string(const char *);
 struct tokstr *tokstr_string(const char *);
 
 // tokstr_next -- return next token from an iterator (which must be free()'d)
+// (NULL means no more tokens are available.)
 char *tokstr_next(struct tokstr *, const char *);
 
-// tokstr_next_copy -- return next token from an iterator (copy)
+// tokstr_next_copy -- copy next token from an iterator; return size, 0, or -1
+// (0 means no more tokens are available.)
 ssize_t tokstr_next_copy(struct tokstr *, const char *, char *, size_t);
 
 // tokstr_next_region -- return next token from iterator (zero-copy)
+// (.base == NULL means no more tokens are available.)
 struct tokstr_reg tokstr_next_region(struct tokstr *, const char *);
 
 // tokstr_last -- destroy an iterator and release all of its internal resources

--- a/tokstr.h
+++ b/tokstr.h
@@ -49,7 +49,7 @@ struct tokstr *tokstr_string(const char *);
 // tokstr_string -- create an iterator for a nul-terminated string
 struct tokstr *tokstr_string(const char *);
 
-// tokstr_next -- return next token from an iterator (strndup)
+// tokstr_next -- return next token from an iterator (which must be free()'d)
 char *tokstr_next(struct tokstr *, const char *);
 
 // tokstr_next_copy -- return next token from an iterator (copy)

--- a/tokstr.h
+++ b/tokstr.h
@@ -2,32 +2,61 @@
 #define __TOKSTR_H
 
 // tokstr -- textual token iterator with some input independence
+// 2022-01-29 [revised during code review, add regions]
 // 2022-01-25 [initially released inside dnsdbq]
 
-/* example:
+/* example using heap-allocated strings:
 
 	tokstr_t ts = tokstr_string("this:is+-test");
 	for (char *t; (t = tokstr_next(ts, "-:+")) != NULL; free(t))
 		printf("\t\"%s\"\n", t);
 	tokstr_last(&ts);
 
- * will output "this", "is", and "test".
+ * will output "this", "is", and "test". so will this:
+
+	tokstr_t ts = tokstr_string("this:is+-test");
+	for (char t[100]; tokstr_next_copy(ts, "-:+", t, sizeof t) > 0;)
+		printf("\t\"%s\"\n", t);
+	tokstr_last(&ts);
+
+ * as will this:
+
+	tokstr_t ts = tokstr_string("this:is+-test");
+	for (;;) {
+		struct tokstr_reg t = tokstr_next_region(ts, "-:+");
+		if (t.base == NULL)
+			break;
+		printf("\t\"%*s\"\n", t.size, t.base);
+	}
+	tokstr_last(&ts);
+
  */
 
 // tokstr_t -- opaque handle for one iterator
 struct tokstr;
 typedef struct tokstr *tokstr_t;
 
-// tokstr_buffer -- create an iterator for a counted string
-tokstr_t tokstr_buffer(const char *source, size_t size);
+struct tokstr_reg {
+	const char		*base;
+	size_t			size;
+};
+
+// tokstr_region -- create an iterator for a counted string
+tokstr_t tokstr_region(struct tokstr_reg);
 
 // tokstr_string -- create an iterator for a nul-terminated string
-tokstr_t tokstr_string(const char *source);
+tokstr_t tokstr_string(const char *);
 
 // tokstr_next -- return next token from an iterator (caller must free() this)
-char *tokstr_next(tokstr_t ts, const char *delims);
+char *tokstr_next(tokstr_t, const char *);
+
+// tokstr_next_copy -- copy next token from an iterator; return size, 0, or -1
+ssize_t tokstr_next_copy(tokstr_t, const char *, char *, size_t);
+
+// tokstr_next_region -- return region of next token
+struct tokstr_reg tokstr_next_region(tokstr_t, const char *);
 
 // tokstr_last -- destroy an iterator and release all of its internal resources
-void tokstr_last(tokstr_t *pts);
+void tokstr_last(tokstr_t *);
 
 #endif /*__TOKSTR_H*/


### PR DESCRIPTION
revise api to communicate in terms of regions. null terminated input and output strings are still available (strndup), but so is zero-copy and copy. this completes the processing of reviews garnered on codereview.stackexchange.com.