### PR TITLE
Add build dependencies for Amazon Linux 2023

### DIFF
--- a/README
+++ b/README
@@ -95,6 +95,17 @@ Installing dependencies:
 
     On macOS:
 	brew install jansson
+	
+	On Amazon Linux 2023 (AWS Ec2):
+	# A plain vanilla Amazon Linux AMI comes with with curl-minimal, and 'make' will 
+	# fail with an error that curl/curl.h is not found. Installing the following packages
+	# will allow dnsdbq to compile on a fresh Amazon Linux 2023 AMI:
+
+	yum install make 
+	yum install git 
+	yum install gcc 
+	yum install libcurl-devel 
+	yum install jansson-devel
 
 
 Building and installing:


### PR DESCRIPTION
Added dependencies for a successful build on Amazon Linux to the README file