### PR TITLE
display millisecond-granularity timestamps in logging and debugging

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -21,6 +21,9 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
+
+#include "time.h"
 
 /* Note that cygwin has a crippled libresolv that does not
  * include the not so recent ns_initparse() function, etc.
@@ -79,7 +82,7 @@ debug(bool want_header, const char *fmtstr, ...) {
 
 	va_start(ap, fmtstr);
 	if (want_header)
-		fputs("debug: ", stderr);
+		fprintf(stderr, "debug [%s]: ", timeval_str(NULL));
 	vfprintf(stderr, fmtstr, ap);
 	va_end(ap);
 }

--- a/defs.h
+++ b/defs.h
@@ -82,7 +82,7 @@ debug(bool want_header, const char *fmtstr, ...) {
 
 	va_start(ap, fmtstr);
 	if (want_header)
-		fprintf(stderr, "debug [%s]: ", timeval_str(NULL));
+		fprintf(stderr, "debug [%s]: ", timeval_str(NULL, true));
 	vfprintf(stderr, fmtstr, ap);
 	va_end(ap);
 }

--- a/globals.h
+++ b/globals.h
@@ -90,8 +90,7 @@ my_logf(const char *fmtstr, ...) {
 	va_list ap;
 
 	va_start(ap, fmtstr);
-	fprintf(stderr, "%s [%s]: ", program_name,
-		time_str((u_long)time(NULL), false));
+	fprintf(stderr, "%s [%s]: ", program_name, timeval_str(NULL));
 	vfprintf(stderr, fmtstr, ap);
 	putc('\n', stderr);
 }

--- a/globals.h
+++ b/globals.h
@@ -90,7 +90,7 @@ my_logf(const char *fmtstr, ...) {
 	va_list ap;
 
 	va_start(ap, fmtstr);
-	fprintf(stderr, "%s [%s]: ", program_name, timeval_str(NULL));
+	fprintf(stderr, "%s [%s]: ", program_name, timeval_str(NULL, true));
 	vfprintf(stderr, fmtstr, ap);
 	putc('\n', stderr);
 }

--- a/time.c
+++ b/time.c
@@ -57,22 +57,30 @@ time_str(u_long x, bool iso8601fmt) {
 	return ret;
 }
 
-/* timeval_str -- format one timestamp (NULL means current time) and return it
+/* timeval_str -- format one timeval (NULL means current time)
+ *
+ * returns static string.
+ *
+ * output format: yyyy-mm-dd hh:mm:ss.fff[fff]
  */
-const char *timeval_str(const struct timeval *src) {
-	static char ret[sizeof "yyyy-mm-dd hh:mm:ss.mmm"];
+const char *
+timeval_str(const struct timeval *src, bool milliseconds) {
+	static char ret[sizeof "yyyy-mm-dd hh:mm:ss.ffffff"];
 	char *dst;
 
 	struct timeval now;
 	if (src == NULL) {
-	  gettimeofday(&now, NULL);
-	  src = &now;
+		gettimeofday(&now, NULL);
+		src = &now;
 	}
 
 	time_t t = (time_t)src->tv_sec;
 	struct tm result, *y = gmtime_r(&t, &result);
 	dst = ret + strftime(ret, sizeof ret, "%F %T", y);
-	sprintf(dst, ".%03d", src->tv_usec % 1000);
+	if (milliseconds)
+		sprintf(dst, ".%03d", src->tv_usec % 1000);
+	else
+		sprintf(dst, ".%06d", src->tv_usec % 1000000);
 	return ret;
 }
 

--- a/time.c
+++ b/time.c
@@ -40,7 +40,9 @@ time_cmp(u_long a, u_long b) {
 	return 0;
 }
 
-/* time_str -- format one (possibly zero) timestamp (returns static string)
+/* time_str -- format one (possibly zero) timestamp
+ *
+ *	returns static string. always uses GMT.
  */
 const char *
 time_str(u_long x, bool iso8601fmt) {
@@ -59,7 +61,7 @@ time_str(u_long x, bool iso8601fmt) {
 
 /* timeval_str -- format one timeval (NULL means current time)
  *
- * returns static string.
+ * returns static string. always uses GMT.
  *
  * output format: yyyy-mm-dd hh:mm:ss.fff[fff]
  */

--- a/time.c
+++ b/time.c
@@ -57,6 +57,25 @@ time_str(u_long x, bool iso8601fmt) {
 	return ret;
 }
 
+/* timeval_str -- format one timestamp (NULL means current time) and return it
+ */
+const char *timeval_str(const struct timeval *src) {
+	static char ret[sizeof "yyyy-mm-dd hh:mm:ss.mmm"];
+	char *dst;
+
+	struct timeval now;
+	if (src == NULL) {
+	  gettimeofday(&now, NULL);
+	  src = &now;
+	}
+
+	time_t t = (time_t)src->tv_sec;
+	struct tm result, *y = gmtime_r(&t, &result);
+	dst = ret + strftime(ret, sizeof ret, "%F %T", y);
+	sprintf(dst, ".%03d", src->tv_usec % 1000);
+	return ret;
+}
+
 /* time_get -- parse and return one (possibly relative) timestamp.
  */
 int

--- a/time.h
+++ b/time.h
@@ -17,11 +17,13 @@
 #ifndef TIME_H_INCLUDED
 #define TIME_H_INCLUDED 1
 
+#include <sys/time.h>
 #include <sys/types.h>
 #include <stdbool.h>
 
 int time_cmp(u_long, u_long);
 const char *time_str(u_long, bool);
-int time_get(const char *src, u_long *dst);
+const char *timeval_str(const struct timeval *);
+int time_get(const char *, u_long *);
 
 #endif /*TIME_H_INCLUDED*/

--- a/time.h
+++ b/time.h
@@ -23,7 +23,7 @@
 
 int time_cmp(u_long, u_long);
 const char *time_str(u_long, bool);
-const char *timeval_str(const struct timeval *);
+const char *timeval_str(const struct timeval *, bool);
 int time_get(const char *, u_long *);
 
 #endif /*TIME_H_INCLUDED*/


### PR DESCRIPTION
needed better resolution on time stamps to suss out performance limits.