### PR TITLE
add -C option to select a cookie jar file for libcurl

### DIFF
--- a/dnsdbq.c
+++ b/dnsdbq.c
@@ -156,7 +156,7 @@ main(int argc, char *argv[]) {
 
 	/* process the command line options. */
 	while ((ch = getopt(argc, argv,
-			    "D:R:r:N:n:i:M:u:p:t:b:k:J:V:T:0:o:"
+			    "C:D:R:r:N:n:i:M:u:p:t:b:k:J:V:T:0:o:"
 			    "adfhIjmqSsUv468" QPARAM_GETOPT))
 	       != -1)
 	{
@@ -186,6 +186,9 @@ main(int argc, char *argv[]) {
 		    }
 		case 'a':
 			asinfo_lookup = true;
+			break;
+		case 'C':
+			cookie_file = strdup(optarg);
 			break;
 		case 'D':
 			asinfo_domain = optarg;
@@ -700,6 +703,7 @@ my_exit(int code) {
 
 	/* globals which may have been initialized, are to be freed. */
 	DESTROY(config_file);
+	DESTROY(cookie_file);
 	if (psys != NULL)
 		psys->destroy();
 

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -31,6 +31,7 @@
 .Op Fl L Ar output_limit
 .Op Fl l Ar query_limit
 .Op Fl M Ar max_count
+.Op Fl C Ar cookie_file
 .Op Fl N Ar hex[/rrtype[,...]]
 .Op Fl n Ar name[/rrtype[,...]]
 .Op Fl O Ar offset
@@ -115,6 +116,8 @@ specified once, and for reasons of geometry, affects both
 and
 .Fl B
 if both are specified.
+.It Fl C
+specify a cookie file to be used by libcurl.
 .It Fl D
 specify the data source for ASINFO/CIDR annotations, if enabled by
 .Fl a .

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -117,7 +117,9 @@ and
 .Fl B
 if both are specified.
 .It Fl C
-specify a cookie file to be used by libcurl.
+specify a cookie file to be used by libcurl (read-only; analagous to
+.Xr curl 1
+-b). Typically this will be used for service authentication.
 .It Fl D
 specify the data source for ASINFO/CIDR annotations, if enabled by
 .Fl a .
@@ -665,4 +667,5 @@ error such as specifying the wrong server hostname.
 .Xr dig 1 ,
 .Xr jq 1 ,
 .Xr libcurl 3 ,
-.Xr dnstable-encoding 5
+.Xr dnstable-encoding 5 ,
+.Ic "https://curl.se/docs/http-cookies.html"

--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -117,7 +117,7 @@ and
 .Fl B
 if both are specified.
 .It Fl C
-specify a cookie file to be used by libcurl (read-only; analagous to
+specify a cookie file to be used by libcurl (read-only; analogous to
 .Xr curl 1
 -b). Typically this will be used for service authentication.
 .It Fl D

--- a/globals.h
+++ b/globals.h
@@ -49,6 +49,7 @@ EXTERN	const char status_error[]	INIT("ERROR");
 EXTERN	const char *asinfo_domain	INIT("asn.routeviews.org");
 EXTERN	struct qparam qparam_empty INIT({ .query_limit = -1L,
 			.explicit_output_limit = -1L, .output_limit = -1L });
+EXTERN	char *cookie_file		INIT(NULL);
 EXTERN	char *config_file		INIT(NULL);
 EXTERN	verb_ct pverb			INIT(NULL);
 EXTERN	pdns_system_ct psys		INIT(NULL);

--- a/globals.h
+++ b/globals.h
@@ -36,7 +36,7 @@ extern const struct verb verbs[];
 #endif
 
 EXTERN	const char id_swclient[]	INIT("dnsdbq");
-EXTERN	const char id_version[]		INIT("2.6.4");
+EXTERN	const char id_version[]		INIT("2.6.5");
 EXTERN	const char *program_name	INIT(NULL);
 EXTERN	const char path_sort[]		INIT("/usr/bin/sort");
 EXTERN	const char json_header[]	INIT("Accept: application/json");

--- a/netio.c
+++ b/netio.c
@@ -122,6 +122,10 @@ create_fetch(query_t query, char *url) {
 	if (psys->auth != NULL)
 	    psys->auth(fetch);
 
+	/* if user specified a cookie file, tell libcurl about it. */
+	if (cookie_file != NULL)
+		curl_easy_setopt(fetch->easy, CURLOPT_COOKIEFILE, cookie_file);
+
 	if (psys->encap == encap_saf)
 		fetch->hdrs = curl_slist_append(fetch->hdrs, jsonl_header);
 	else


### PR DESCRIPTION
there exist cookie-based authentication schemes, make sure dnsdbq can access them.