### PR TITLE
fix spelling

### DIFF
--- a/dnsdbq.man
+++ b/dnsdbq.man
@@ -643,7 +643,7 @@ specifies the configuration file to use, overriding the internal search list.
 contains the user's apikey. The older APIKEY environment variable has
 been retired, though it can still be used in the configuration file.
 Note that environment variables are unprotected, and putting one's API
-key in an unprotected place could cause inadvertant sharing.
+key in an unprotected place could cause inadvertent sharing.
 .It Ev DNSDB_SERVER
 contains the URL of the DNSDB API server, and optionally a URI prefix to be
 used (default is "/lookup"). If not set, the configuration file is consulted.


### PR DESCRIPTION
It's "inadvertent" not "inadvertant" AFAIK.
Found by Debian's automated (spel)lintian tool (https://manpages.debian.org/testing/lintian/spellintian.1.en.html).